### PR TITLE
The top-level Rakefile requires Bundler awareness.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,8 @@ require 'rake'
 require 'fileutils'
 require 'pathname'
 
+UsingBundler = !!ENV['BUNDLE_GEMFILE']
+
 Projects = ['rspec-expectations', 'rspec-mocks', 'rspec-core', 'rspec', 'rspec-rails']
 BaseRspecPath = Pathname.new(Dir.pwd)
 ReposPath = BaseRspecPath.join('repos')
@@ -177,7 +179,14 @@ end
 task :setup => ["git:clone", "bundle:install"]
 
 task :default do
-  run_command 'rake'
+  if UsingBundler
+    Bundler.with_clean_env do
+      ENV.delete 'BUNDLE_GEMFILE'
+      run_command 'bin/rake'
+    end
+  else
+    run_command 'rake'
+  end
 end
 
 task :authors do


### PR DESCRIPTION
When running the bin/rake Bundler binstub, the binstub sets ENV['BUNDLE_GEMFILE'] which is inherited by calls to the rake environments of the Projects. The top level Gemfile only includes Rake and Thor, so it's not surprising that the builds can't continue. MRI 1.9.2 appears to be able to work around this with "export RUBYOPT=rubygems", but that seems inelegant at best.

This change determines if the Rakefile was launched through a bundled rake; if so, it uses Bundler.with_clean_env (and deletes the BUNDLE_GEMFILE for good measure; necessary if you use the binstub, less necessary if you use "bundle exec rake") and instead of running 'rake', it runs 'bin/rake' to force the use of the Project rake binstub, forcing the use of the correct Gemfile and bundler environment.

The non-bundler path works as it always has.
