### PR TITLE
Replace the rubygems symbol with explicit https rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 gem "rake", "~> 10.0.0"
 gem "thor", "~> 0.14.6"


### PR DESCRIPTION
This was causing an error when setting up the rspec-dev environment.
This fixes the error.
