### PR TITLE
Fix readme to not reference RSpec 2

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,7 @@
-# Rspec 2 Development
+# RSpec Development
 
-This repository is for anyone interested in contributing to rspec-2 or
-rspec-rails-2.
+This repository is for anyone interested in contributing to rspec or
+rspec-rails.
 
 ## Environment
 


### PR DESCRIPTION
RSpec 2 is no longer the current version of RSpec.
