### PR TITLE
Disable Style/SpecialGlobalVars RuboCop rule

### DIFF
--- a/travis/.rubocop_rspec_base.yml
+++ b/travis/.rubocop_rspec_base.yml
@@ -114,6 +114,10 @@ SpaceAroundEqualsInParameterDefault:
 StringLiterals:
   Enabled: false
 
+# This rule favors constant names from the English standard library which we don't load.
+Style/SpecialGlobalVars:
+  Enabled: false
+
 Style/TrailingComma:
   Enabled: false
 


### PR DESCRIPTION
Does it make sense to disable this rule across all RSpec projects?

https://github.com/rspec/rspec-core/pull/1663#discussion_r16278677
