### PR TITLE
Add ruby 2.1.3 to .travis.yml

### DIFF
--- a/travis/.travis.yml
+++ b/travis/.travis.yml
@@ -15,6 +15,7 @@ rvm:
   - 2.1.0
   - 2.1.1
   - 2.1.2
+  - 2.1.3
   - ruby-head
   - ree
   - jruby-18mode


### PR DESCRIPTION
Should be merged when rspec/rspec-core#1722 rspec/rspec-mocks#791 rspec/rspec-expectations#660 rspec/rspec-support#114 go green, or whatever
