### PR TITLE
Use bundler standalone for app veyor builds.

### DIFF
--- a/travis/appveyor.yml
+++ b/travis/appveyor.yml
@@ -15,7 +15,8 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - ruby --version
   - gem --version
-  - gem install bundler
+  # We lock to 1.7.7 to avoid warnings from 1.7.8
+  - gem install bundler -v=1.7.7
   - bundler --version
   - bundle install
   - cinst ansicon


### PR DESCRIPTION
Our specs that check there are no load-time warnings are failing
due to a warning coming from bundler:

C:/Ruby193/lib/ruby/gems/1.9.1/gems/bundler-1.7.8/lib/bundler/source/rubygems.rb:191: warning: shadowing outer local variable - spec

By avoiding loading bundler we can avoid this warning.
