### PR TITLE
Remove || which causes `set -e` not to work

### DIFF
--- a/travis/script/travis_functions.sh
+++ b/travis/script/travis_functions.sh
@@ -49,7 +49,8 @@ fold() {
     travis_time_start
   fi
 
-  "$@" || status=$?
+  "$@"
+  status=$?
 
   [ -z "$TRAVIS" ] || travis_time_finish
 


### PR DESCRIPTION
I believe this is the issue causing #97.

Short story: `set -e` is complicated (http://mywiki.wooledge.org/BashFAQ/105, http://fvue.nl/wiki/Bash:_Error_handling)

Long story: When you make a command the first part of an `||` it turns off the normal `set -e` behavior for that command. What was happening specifically for `check_documentation_coverage` was that the first YARD command would fail, but the second would still run and succeed, and so the captured exit code stored as `$result` was still 0 and so the error checking code in `fold` didn't really matter. I'm not sure if it _ever_ would matter and can be removed, but I guess its harmless.

:santa:
