### PR TITLE
Stop allowing JRuby failures.

### DIFF
--- a/travis/.travis.yml
+++ b/travis/.travis.yml
@@ -31,7 +31,4 @@ matrix:
     - rvm: jruby-head
     - rvm: ruby-head
     - rvm: rbx
-    # These two are temporary until https://github.com/travis-ci/travis-ci/issues/3067 is solved.
-    - rvm: jruby-18mode
-    - rvm: jruby
   fast_finish: true


### PR DESCRIPTION
travis-ci/travis-ci#3067 has been fixed.