### PR TITLE
Stop skipping parts of the build on non-MRI rubies.

### DIFF
--- a/travis/script/clone_all_rspec_repos
+++ b/travis/script/clone_all_rspec_repos
@@ -2,20 +2,19 @@
 set -e
 source script/functions.sh
 
+pushd ..
+
+clone_repo "rspec"
+clone_repo "rspec-core"
+clone_repo "rspec-expectations"
+clone_repo "rspec-mocks"
+
 if is_mri; then
-  pushd ..
-
-  clone_repo "rspec"
-  clone_repo "rspec-core"
-  clone_repo "rspec-expectations"
-  clone_repo "rspec-mocks"
   clone_repo "rspec-rails"
-
-  if rspec_support_compatible; then
-    clone_repo "rspec-support"
-  fi
-
-  popd
-else
-  echo "Not cloning all repos since we are not on MRI and they are only needed for the MRI build"
 fi
+
+if rspec_support_compatible; then
+  clone_repo "rspec-support"
+fi
+
+popd

--- a/travis/script/functions.sh
+++ b/travis/script/functions.sh
@@ -66,7 +66,7 @@ function run_spec_suite_for {
     pushd ../$1
     unset BUNDLE_GEMFILE
     bundle_install_flags=`cat .travis.yml | grep bundler_args | tr -d '"' | grep -o " .*"`
-    travis_retry eval "bundle install $bundle_install_flags"
+    travis_retry eval "time bundle install $bundle_install_flags"
     run_specs_and_record_done
     popd
   fi;

--- a/travis/script/functions.sh
+++ b/travis/script/functions.sh
@@ -55,9 +55,13 @@ function run_cukes {
 function run_specs_one_by_one {
   echo "Running each spec file, one-by-one..."
 
-  for file in `find spec -iname '*_spec.rb'`; do
-    bin/rspec $file -b --format progress
-  done
+  if is_mri; then
+    for file in `find spec -iname '*_spec.rb'`; do
+      bin/rspec $file -b --format progress
+    done
+  else
+    echo "Skipping one-by-one specs on non-MRI rubies as they tend to have long boot times"
+  fi
 }
 
 function run_spec_suite_for {

--- a/travis/script/functions.sh
+++ b/travis/script/functions.sh
@@ -118,7 +118,12 @@ function run_all_spec_suites {
   fold "rspec-core specs" run_spec_suite_for "rspec-core"
   fold "rspec-expectations specs" run_spec_suite_for "rspec-expectations"
   fold "rspec-mocks specs" run_spec_suite_for "rspec-mocks"
-  fold "rspec-rails specs" run_spec_suite_for "rspec-rails"
+
+  if is_mri; then
+    fold "rspec-rails specs" run_spec_suite_for "rspec-rails"
+  else
+    echo "Skipping rspec-rails specs on non-MRI rubies"
+  fi
 
   if rspec_support_compatible; then
     fold "rspec-support specs" run_spec_suite_for "rspec-support"

--- a/travis/script/predicate_functions.sh
+++ b/travis/script/predicate_functions.sh
@@ -8,6 +8,18 @@ function is_mri {
   fi;
 }
 
+function is_jruby_20_mode {
+  if [ -z "$JRUBY_OPTS" ]; then
+    if ruby -e "exit(RUBY_VERSION == '2.0.0')"; then
+      return 0
+    else
+      return 1
+    fi
+  else
+    return 1
+  fi
+}
+
 function is_mri_192 {
   if is_mri; then
     if ruby -e "exit(RUBY_VERSION == '1.9.2')"; then

--- a/travis/script/run_build
+++ b/travis/script/run_build
@@ -18,4 +18,8 @@ if style_and_lint_enforced; then
   fold "rubocop" check_style_and_lint
 fi
 
-run_all_spec_suites
+if is_jruby_20_mode; then
+  echo "Skipping other specs suites on JRuby 2.0 mode because it is so much slower"
+else
+  run_all_spec_suites
+fi

--- a/travis/script/run_build
+++ b/travis/script/run_build
@@ -18,8 +18,4 @@ if style_and_lint_enforced; then
   fold "rubocop" check_style_and_lint
 fi
 
-if is_mri; then
-  run_all_spec_suites
-else
-  echo "Skipping the rest of the build on non-MRI rubies"
-fi
+run_all_spec_suites


### PR DESCRIPTION
Historically we did this because of travis build speeds.
However, recent build changes (including travis’s new
container infrastructure and bundler caching) have
greatly improved the speed of builds and I’m hopeful
we can do the full build on all rubies now. The main
slowness on non-MRI rubies is the cucumber features,
anyway, since they frequently shell out and start
a new ruby interpreter which is slow on non-MRI
rubies.