### PR TITLE
Add command to update rspec.github.io docs.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ require 'time'
 require 'date'
 
 Projects = ['rspec', 'rspec-core', 'rspec-expectations', 'rspec-mocks', 'rspec-rails', 'rspec-support']
+UnDocumentedProjects = %w[ rspec rspec-support ]
 BaseRspecPath = Pathname.new(Dir.pwd)
 ReposPath = BaseRspecPath.join('repos')
 
@@ -54,6 +55,17 @@ end
 desc "run an arbitrary command against all repos"
 task :run, :command do |t, args|
   run_command args[:command]
+end
+
+desc "Updates the rspec.github.io docs"
+task :update_docs, [:version, :branch, :website_path] do |t, args|
+  args.with_defaults(:website_path => "../rspec.github.io")
+  run_command "git checkout #{args[:branch]}", :except => UnDocumentedProjects
+  each_project :except => UnDocumentedProjects do |project|
+    cmd = "RUBYOPT='-I#{args[:website_path]}/lib' bundle exec yard --plugin rspec-docs-template --output-dir #{args[:website_path]}/source/documentation/#{args[:version]}/#{project}/"
+    puts cmd
+    Bundler.clean_system(cmd)
+  end
 end
 
 namespace :gem do


### PR DESCRIPTION
This adds a command that will regenerate all the YARD docs for rspec.github.io:

``` 
$ bundle exec rake "update_docs[3.2, master]"
# or
$ bundle exec rake "update_docs[3.1, 3-1-maintenance]"
```

Longer term we might want to hook it into the release tasks so the docs are auto-updated but this seemed a good first step.

/cc @JonRowe 