### PR TITLE
Windows compatability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ repos/*
 bundle
 
 config/github_oauth_token.txt
+/.idea/
+/vendor/

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 gem "rake", "~> 10.0.0"
 gem "thor", "~> 0.14.6"
-gem "yard", "~> 0.7.4"
+gem "yard", "~> 0.8.7"
 gem "octokit", "~> 2.7"

--- a/README.markdown
+++ b/README.markdown
@@ -19,7 +19,13 @@ installed ruby (not system ruby) and a clean gemset dedicated to rspec-dev:
 
 [rbenv](https://github.com/sstephenson/rbenv) is also supported.
 
-Windows users can use [uru](https://bitbucket.org/jonforums/uru).
+Windows users are recommended to use
+[RubyInstaller](http://rubyinstaller.org/downloads/) to install Ruby versions
+and [uru](https://bitbucket.org/jonforums/uru) to manage them.
+
+Windows users will also need to install the
+[RubyInstaller Development Kit](http://rubyinstaller.org/downloads/)
+(aka DevKit) to enable Bundler to build and install native gems.
 
 If you use a different Ruby version manager (or none at all), the important
 thing is that you have a sandboxed gem environment that does not require you to
@@ -38,9 +44,9 @@ bootstrapped:
 
     git clone git://github.com/rspec/rspec-dev.git
     cd rspec-dev
-    bundle install --binstubs
-    bin/rake setup
-    bin/rake # runs tests in every repository
+    bundle install --path=vendor/bundle
+    bundle exec rake setup
+    bundle exec rake # runs tests in every repository
 
 If all goes well, you'll end up seeing a lot of passing cucumber features
 and rspec code examples. You'll also have a directory structure that looks
@@ -60,7 +66,7 @@ like this:
 After the initial clone you can run `rake git:pull` from the rspec-dev
 directory to update all of the rspec repos (in repos).
 
-Run `rake -T` to see the available tasks for dev mode.
+Run `bundle exec rake -T` to see the available tasks for dev mode.
 
 # Contributing
 

--- a/README.markdown
+++ b/README.markdown
@@ -44,7 +44,7 @@ bootstrapped:
 
     git clone git://github.com/rspec/rspec-dev.git
     cd rspec-dev
-    bundle install --path=vendor/bundle
+    bundle install --binstubs
     bundle exec rake setup
     bundle exec rake # runs tests in every repository
 

--- a/Rakefile
+++ b/Rakefile
@@ -84,7 +84,7 @@ namespace :gem do
 
   desc "Build gems"
   task :build => [:clean_pkg_directories] do
-    run_command "bin/rake build"
+    run_command "bundle exec rake build"
   end
 
   task :clean_pkg_directories do
@@ -93,12 +93,12 @@ namespace :gem do
 
   desc "Tag each repo, push the tags, push the gems"
   task :release do
-    run_command "bin/rake release"
+    run_command "bundle exec rake release"
   end
 
   desc "Install all gems locally"
   task :install do
-    run_command "bin/rake install"
+    run_command "bundle exec rake install"
   end
 
   desc "Uninstall gems locally"
@@ -173,7 +173,7 @@ namespace :git do
 end
 
 task :clobber do
-  run_command "bin/rake clobber"
+  run_command "bundle exec rake clobber"
 end
 
 namespace :bundle do
@@ -207,9 +207,9 @@ BASE_BRANCH_MAJOR_VERSION = if BASE_BRANCH == 'master'
 
 def create_pull_request(project_name, branch, base=BASE_BRANCH)
   github_client.create_pull_request(
-    "rspec/#{project_name}", base, branch,
-    "Updates from rspec-dev (#{Date.today.iso8601})",
-    "These are some updates, generated from rspec-dev's rake tasks."
+      "rspec/#{project_name}", base, branch,
+      "Updates from rspec-dev (#{Date.today.iso8601})",
+      "These are some updates, generated from rspec-dev's rake tasks."
   )
 end
 
@@ -239,9 +239,9 @@ namespace :travis do
       lines = file.each_line.each_with_object([]) do |line, all|
         if !comments_added && !line.start_with?('#!')
           all.concat([
-            "# This file was generated on #{Time.now.iso8601} from the rspec-dev repo.\n",
-            "# DO NOT modify it by hand as your changes will get lost the next time it is generated.\n\n",
-          ])
+                         "# This file was generated on #{Time.now.iso8601} from the rspec-dev repo.\n",
+                         "# DO NOT modify it by hand as your changes will get lost the next time it is generated.\n\n",
+                     ])
           comments_added = true
         end
 
@@ -249,9 +249,9 @@ namespace :travis do
       end
 
       ReadFile.new(
-        file.relative_path_from(travis_root),
-        lines.join,
-        file.stat.mode
+          file.relative_path_from(travis_root),
+          lines.join,
+          file.stat.mode
       )
     end
   end
@@ -265,12 +265,12 @@ namespace :travis do
 
     puts "Branch #{name} already exists, delete? [Y/n] or rename new branch? [r[ename] <name>]"
     case STDIN.gets.downcase
-    when /^y/
-      `git branch -D #{name}`
-    when /^r(?:ename)? (.*)$/
-      name = $1
-    else
-      abort "Unknown option: #{input}"
+      when /^y/
+        `git branch -D #{name}`
+      when /^r(?:ename)? (.*)$/
+        name = $1
+      else
+        abort "Unknown option: #{input}"
     end
 
     name
@@ -347,13 +347,13 @@ end
 task :setup => ["git:clone", "bundle:install"]
 
 task :default do
-  run_command "bin/rake"
+  run_command "bundle exec rake"
 end
 
 desc "publish cukes to relishapp.com"
 task :relish, :version do |_, args|
   raise "rake relish[VERSION]" unless args[:version]
-  run_command "bin/rake relish['#{args[:version]}']", :except => ['rspec']
+  run_command "bundle exec rake relish['#{args[:version]}']", :except => ['rspec']
 end
 
 desc "generate release notes from changelogs"
@@ -462,13 +462,13 @@ class VersionStats
       end
 
       authors = logs.split("\n").
-        map{|l| l.sub(/Author: /,'')}.
-        map{|l| l.split('<').first}.
-        map{|l| l.split(' and ')}.flatten.
-        map{|l| l.split('+')}.flatten.
-        map{|l| l.split(',')}.flatten.
-        map{|l| l.strip}.
-        uniq.compact.reject{|n| n == ""}.sort
+          map{|l| l.sub(/Author: /,'')}.
+          map{|l| l.split('<').first}.
+          map{|l| l.split(' and ')}.flatten.
+          map{|l| l.split('+')}.flatten.
+          map{|l| l.split(',')}.flatten.
+          map{|l| l.strip}.
+          uniq.compact.reject{|n| n == ""}.sort
     end
   end
 
@@ -485,7 +485,7 @@ class VersionStats
     @merged_pull_requests ||= count_commits('grep -v Revert | grep "Merge pull request" |')
   end
 
-private
+  private
 
   def count_commits(command_before_count)
     @dirs.reduce(0) do |count_1, dir|

--- a/Rakefile
+++ b/Rakefile
@@ -207,9 +207,9 @@ BASE_BRANCH_MAJOR_VERSION = if BASE_BRANCH == 'master'
 
 def create_pull_request(project_name, branch, base=BASE_BRANCH)
   github_client.create_pull_request(
-      "rspec/#{project_name}", base, branch,
-      "Updates from rspec-dev (#{Date.today.iso8601})",
-      "These are some updates, generated from rspec-dev's rake tasks."
+    "rspec/#{project_name}", base, branch,
+    "Updates from rspec-dev (#{Date.today.iso8601})",
+    "These are some updates, generated from rspec-dev's rake tasks."
   )
 end
 
@@ -239,9 +239,9 @@ namespace :travis do
       lines = file.each_line.each_with_object([]) do |line, all|
         if !comments_added && !line.start_with?('#!')
           all.concat([
-                         "# This file was generated on #{Time.now.iso8601} from the rspec-dev repo.\n",
-                         "# DO NOT modify it by hand as your changes will get lost the next time it is generated.\n\n",
-                     ])
+            "# This file was generated on #{Time.now.iso8601} from the rspec-dev repo.\n",
+            "# DO NOT modify it by hand as your changes will get lost the next time it is generated.\n\n",
+          ])
           comments_added = true
         end
 
@@ -249,9 +249,9 @@ namespace :travis do
       end
 
       ReadFile.new(
-          file.relative_path_from(travis_root),
-          lines.join,
-          file.stat.mode
+        file.relative_path_from(travis_root),
+        lines.join,
+        file.stat.mode
       )
     end
   end
@@ -265,12 +265,12 @@ namespace :travis do
 
     puts "Branch #{name} already exists, delete? [Y/n] or rename new branch? [r[ename] <name>]"
     case STDIN.gets.downcase
-      when /^y/
-        `git branch -D #{name}`
-      when /^r(?:ename)? (.*)$/
-        name = $1
-      else
-        abort "Unknown option: #{input}"
+    when /^y/
+      `git branch -D #{name}`
+    when /^r(?:ename)? (.*)$/
+      name = $1
+    else
+      abort "Unknown option: #{input}"
     end
 
     name
@@ -462,13 +462,13 @@ class VersionStats
       end
 
       authors = logs.split("\n").
-          map{|l| l.sub(/Author: /,'')}.
-          map{|l| l.split('<').first}.
-          map{|l| l.split(' and ')}.flatten.
-          map{|l| l.split('+')}.flatten.
-          map{|l| l.split(',')}.flatten.
-          map{|l| l.strip}.
-          uniq.compact.reject{|n| n == ""}.sort
+        map{|l| l.sub(/Author: /,'')}.
+        map{|l| l.split('<').first}.
+        map{|l| l.split(' and ')}.flatten.
+        map{|l| l.split('+')}.flatten.
+        map{|l| l.split(',')}.flatten.
+        map{|l| l.strip}.
+        uniq.compact.reject{|n| n == ""}.sort
     end
   end
 
@@ -485,7 +485,7 @@ class VersionStats
     @merged_pull_requests ||= count_commits('grep -v Revert | grep "Merge pull request" |')
   end
 
-  private
+private
 
   def count_commits(command_before_count)
     @dirs.reduce(0) do |count_1, dir|


### PR DESCRIPTION
For this project to work better on Windows, a few minor changes are needed:
- Don't use `bin/rake` stubs created by Bundler's `--binstubs` option.  The stubs are a handy convenience to save typing but sadly they only work on Mac/Linux.
- Use a newer version of the `yard` gem

Also added some tips on Ruby installation to the README.
