### PR TITLE
Whitelist branches for travis.

### DIFF
--- a/travis/.travis.yml
+++ b/travis/.travis.yml
@@ -36,3 +36,7 @@ matrix:
     - rvm: ruby-head
     - rvm: rbx
   fast_finish: true
+branches:
+  only:
+    - master
+    - /^\d+-\d+-maintenance$/


### PR DESCRIPTION
Without this setting, travis runs 2 builds for each
PR that is from a non-fork branch on one of our repos:
one for the HEAD of the branch, plus one for the merge
commit created by GitHub. That’s what the recent
`travis-ci/push` vs `travis-ci/pr` checks we’re seeing are.

Those are extra checks we don’t need that take up extra build
capacity. It’s better to just build commits against the master
and maintenance branches, and any PRs that target those branches.