### PR TITLE
Remove pinned version of bundler for appveyor

### DIFF
--- a/travis/appveyor.yml
+++ b/travis/appveyor.yml
@@ -15,8 +15,7 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - ruby --version
   - gem --version
-  # We lock to 1.7.7 to avoid warnings from 1.7.8
-  - gem install bundler -v=1.7.7
+  - gem install bundler
   - bundler --version
   - bundle install
   - cinst ansicon


### PR DESCRIPTION
We're on a more recent version now so lets remove this.