### PR TITLE
Rakefile tasks for code of conduct updates

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -286,7 +286,7 @@ end
 
 namespace :common_markdown_files do
   def update_common_markdown_files_in_repos
-    update_files_in_repos('common markdown files') do |name|
+    update_files_in_repos('common markdown files', ' [ci skip]') do |name|
       common_markdown_files_with_comments.each do |file|
         full_file_name = ReposPath.join(name, file.file_name)
         full_file_name.write(file.contents)
@@ -472,7 +472,7 @@ def force_update(branch)
   end
 end
 
-def update_files_in_repos(purpose)
+def update_files_in_repos(purpose, suffix='')
   branch_name = "update-#{purpose.gsub ' ', '-'}-#{Date.today.iso8601}-for-#{BASE_BRANCH}"
 
   each_project_with_common_build do |proj|
@@ -491,7 +491,7 @@ def update_files_in_repos(purpose)
     yield name
 
     sh "git add ."
-    sh "git commit -m 'Updated #{purpose} (from rspec-dev)'"
+    sh "git commit -m 'Updated #{purpose} (from rspec-dev)#{suffix}'"
   end
 
   branch_name

--- a/Rakefile
+++ b/Rakefile
@@ -284,10 +284,10 @@ namespace :travis do
   end
 end
 
-namespace :code_of_conduct do
-  def update_conduct_files_in_repos
-    update_files_in_repos('code of conduct') do |name|
-      conduct_files_with_comments.each do |file|
+namespace :common_markdown_files do
+  def update_common_markdown_files_in_repos
+    update_files_in_repos('common markdown files') do |name|
+      common_markdown_files_with_comments.each do |file|
         full_file_name = ReposPath.join(name, file.file_name)
         full_file_name.write(file.contents)
         full_file_name.chmod(file.mode) # ensure executables are set
@@ -295,9 +295,9 @@ namespace :code_of_conduct do
     end
   end
 
-  def conduct_files_with_comments
-    conduct_root = BaseRspecPath.join('code_of_conduct')
-    file_names = Pathname.glob(conduct_root.join('**', '{*,.*}')).select do |f|
+  def common_markdown_files_with_comments
+    markdown_root = BaseRspecPath.join('common_markdown_files')
+    file_names = Pathname.glob(markdown_root.join('**', '{*,.*}')).select do |f|
       f.file?
     end
 
@@ -318,21 +318,21 @@ namespace :code_of_conduct do
       end
 
       ReadFile.new(
-        file.relative_path_from(conduct_root),
+        file.relative_path_from(markdown_root),
         lines.join,
         file.stat.mode
       )
     end
   end
 
-  desc "Update code of conduct files"
+  desc "Update common markdown files"
   task :update_files do
-    update_conduct_files_in_repos
+    update_common_markdown_files_in_repos
   end
 
-  desc "Updates the code of conduct files and creates a PR"
+  desc "Updates the common markdown files files and creates a PR"
   task :create_pr_with_updates do
-    force_update update_conduct_files_in_repos
+    force_update update_common_markdown_files_in_repos
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -306,8 +306,10 @@ namespace :code_of_conduct do
       lines = file.each_line.each_with_object([]) do |line, all|
         if !comments_added && !line.start_with?('#!')
           all.concat([
-            "# This file was generated on #{Time.now.iso8601} from the rspec-dev repo.\n",
-            "# DO NOT modify it by hand as your changes will get lost the next time it is generated.\n\n",
+            "<!---\n",
+            "This file was generated on #{Time.now.iso8601} from the rspec-dev repo.\n",
+            "DO NOT modify it by hand as your changes will get lost the next time it is generated.\n",
+            "-->\n\n",
           ])
           comments_added = true
         end

--- a/Rakefile
+++ b/Rakefile
@@ -519,7 +519,7 @@ class VersionStats
         end
       end
 
-      authors = logs.split("\n").
+      logs.split("\n").
         map{|l| l.sub(/Author: /,'')}.
         map{|l| l.split('<').first}.
         map{|l| l.split(' and ')}.flatten.

--- a/common_markdown_files/code_of_conduct.md
+++ b/common_markdown_files/code_of_conduct.md
@@ -1,0 +1,37 @@
+# Contributor Code of Conduct
+
+For the purpose of building a welcoming, harassment-free community that
+values contributions from anyone, the RSpec project has adopted the
+following code of conduct. All contributors and participants (including
+maintainers!) are expected to abide by its terms.
+
+As contributors and maintainers of this project, we pledge to respect all
+people who contribute through reporting issues, posting feature requests,
+updating documentation, submitting pull requests or patches, and other
+activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, religion or similar personal characteristic.
+
+Examples of unacceptable behavior by participants include, but are not limited
+to, the use of sexual language or imagery, derogatory comments or personal
+attacks, trolling, public or private harassment, insults, or other
+unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct. Project maintainers who do not
+follow the Code of Conduct may be removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by opening an issue or contacting one or more of the project
+maintainers.
+
+This Code of Conduct is adapted from the [Contributor
+Covenant](http://contributor-covenant.org), version 1.1.0, available at
+[http://contributor-covenant.org/version/1/1/0/](http://contributor-covenant.org/version/1/1/0/)


### PR DESCRIPTION
This is setup for #124, it adds rake tasks for updating code of conduct files across all rspec repos, and a blank code of conduct file ready for whatever we decide to go with in #124.