### PR TITLE
Improve experience of running `script/run_build` locally.

### DIFF
--- a/travis/script/functions.sh
+++ b/travis/script/functions.sh
@@ -64,13 +64,22 @@ function run_specs_one_by_one {
 
 function run_spec_suite_for {
   if [ ! -f ../$1/$SPECS_HAVE_RUN_FILE ]; then # don't rerun specs that have already run
-    echo "Running specs for $1"
-    pushd ../$1
-    unset BUNDLE_GEMFILE
-    bundle_install_flags=`cat .travis.yml | grep bundler_args | tr -d '"' | grep -o " .*"`
-    travis_retry eval "bundle install $bundle_install_flags"
-    run_specs_and_record_done
-    popd
+    if [ -d ../$1 ]; then
+      echo "Running specs for $1"
+      pushd ../$1
+      unset BUNDLE_GEMFILE
+      bundle_install_flags=`cat .travis.yml | grep bundler_args | tr -d '"' | grep -o " .*"`
+      travis_retry eval "bundle install $bundle_install_flags"
+      run_specs_and_record_done
+      popd
+    else
+      echo ""
+      echo "WARNING: The ../$1 directory does not exist. Usually the"
+      echo "travis build cds into that directory and run the specs to"
+      echo "ensure the specs still pass with your latest changes, but"
+      echo "we are going to skip that step."
+      echo ""
+    fi;
   fi;
 }
 
@@ -116,7 +125,6 @@ function check_style_and_lint {
 }
 
 function run_all_spec_suites {
-  fold "one-by-one specs" run_specs_one_by_one
   fold "rspec-core specs" run_spec_suite_for "rspec-core"
   fold "rspec-expectations specs" run_spec_suite_for "rspec-expectations"
   fold "rspec-mocks specs" run_spec_suite_for "rspec-mocks"

--- a/travis/script/run_build
+++ b/travis/script/run_build
@@ -19,6 +19,7 @@ if style_and_lint_enforced; then
 fi
 
 if is_mri; then
+  fold "one-by-one specs" run_specs_one_by_one
   run_all_spec_suites
 else
   echo "Skipping the rest of the build on non-MRI rubies"

--- a/travis/script/travis_functions.sh
+++ b/travis/script/travis_functions.sh
@@ -47,6 +47,8 @@ fold() {
   if [ -n "$TRAVIS" ]; then
     printf "travis_fold:start:%s\r\e[0m" "$name"
     travis_time_start
+  else
+    echo "============= Starting $name ==============="
   fi
 
   "$@"
@@ -57,6 +59,8 @@ fold() {
   if [ "$status" -eq 0 ]; then
     if [ -n "$TRAVIS" ]; then
       printf "travis_fold:end:%s\r\e[0m" "$name"
+    else
+      echo "============= Ending $name ==============="
     fi
   else
     STATUS="$status"


### PR DESCRIPTION
- Make it work when the other repos are not checked out
  in a sibling directory. This ensures that any contributor
  can clone the repo and run `script/run_build` and get
  the build results for all the parts their local environment
  is able to run.
- Provide friendly labels for the parts.
- Move the one-by-one specs part into the `run_build`
  script so it is more obvious where in the flow it is.