### PR TITLE
Add code of conduct.

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,0 +1,37 @@
+# Contributor Code of Conduct
+
+For the purpose of building a welcoming, harassment-free community that
+values contributions from anyone, the RSpec project has adopted the
+following code of conduct. All contributors and participants (including
+maintainers!) are expected to abide by its terms.
+
+As contributors and maintainers of this project, we pledge to respect all
+people who contribute through reporting issues, posting feature requests,
+updating documentation, submitting pull requests or patches, and other
+activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, religion or similar personal characteristic.
+
+Examples of unacceptable behavior by participants include, but are not limited
+to, the use of sexual language or imagery, derogatory comments or personal
+attacks, trolling, public or private harassment, insults, or other
+unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct. Project maintainers who do not
+follow the Code of Conduct may be removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by opening an issue or contacting one or more of the project
+maintainers.
+
+This Code of Conduct is adapted from the [Contributor
+Covenant](http://contributor-covenant.org), version 1.1.0, available at
+[http://contributor-covenant.org/version/1/1/0/](http://contributor-covenant.org/version/1/1/0/)


### PR DESCRIPTION
While not one of the "main" repos, it falls under our "RSpec" umbrella. Adding the CoC to the top level to make it prominent.