### PR TITLE
Include a binstubs check before running CI script

### DIFF
--- a/travis/script/functions.sh
+++ b/travis/script/functions.sh
@@ -83,6 +83,49 @@ function run_spec_suite_for {
   fi;
 }
 
+function check_binstubs {
+  echo "Checking required binstubs"
+
+  local success=0
+  local binstubs=""
+  local gems=""
+
+  if [ ! -x ./bin/rspec ]; then
+    binstubs="$binstubs bin/rspec"
+    gems="$gems rspec-core"
+    success=1
+  fi
+
+  if [ ! -x ./bin/rake ]; then
+    binstubs="$binstubs bin/rake"
+    gems="$gems rake"
+    success=1
+  fi
+
+  if [ ! -x ./bin/cucumber ]; then
+    binstubs="$binstubs bin/cucumber"
+    gems="$gems cucumber"
+    success=1
+  fi
+
+  if [ $success -eq 1 ]; then
+    echo
+    echo "Missing binstubs:$binstubs"
+    echo "Install missing binstubs using one of the following:"
+    echo
+    echo "  # Create the missing binstubs"
+    echo "  $ bundle binstubs$gems"
+    echo
+    echo "  # To binstub all gems"
+    echo "  $ bundle install --binstubs"
+    echo
+    echo "  # To binstub all gems and avoid loading bundler"
+    echo "  $ bundle install --binstubs --standalone"
+  fi
+
+  return $success
+}
+
 function check_documentation_coverage {
   echo "bin/yard stats --list-undoc"
 

--- a/travis/script/run_build
+++ b/travis/script/run_build
@@ -7,6 +7,8 @@ if [ -f script/custom_build_functions.sh ]; then
   source script/custom_build_functions.sh
 fi
 
+fold "binstub check" check_binstubs
+
 fold "specs" run_specs_and_record_done
 fold "cukes" run_cukes
 


### PR DESCRIPTION
Newer RSpec contributors may not have setup binstubs. When running
`script/run_build` locally it errors in confusing ways. Often at this
point they are unsure how to properly get the binstubs onto the system.

This includes a very simplistic check for the non-optional binstubs. It
aggregates the missing binstubs and the associated gems, then provides
the user helpful options on how to get the binstubs.

While talking with the users it was decided that this is a kinder
approach than simply forcing the creating of the binstubs. Better to
inform the user then forcefully inject executables into their system.