### PR TITLE
Upgrade bundler

### DIFF
--- a/travis/.rubocop_rspec_base.yml
+++ b/travis/.rubocop_rspec_base.yml
@@ -98,9 +98,9 @@ Proc:
 RedundantReturn:
   AllowMultipleReturnValues: true
 
-# We have to rescue Exception in the `raise_error` matcher for it to work properly.
+# Exceptions should be rescued with `Support::AllExceptionsExceptOnesWeMustNotRescue`
 RescueException:
-  Enabled: false
+  Enabled: true
 
 # We haven't adopted the `fail` to signal exceptions vs `raise` for re-raises convention.
 SignalException:

--- a/travis/.travis.yml
+++ b/travis/.travis.yml
@@ -5,9 +5,8 @@ cache:
     - ../bundle
 before_install:
   - "script/clone_all_rspec_repos"
-  # Downgrade bundler to work around https://github.com/bundler/bundler/issues/3004
   # Note this doesn't work on JRUBY 2.0.0 mode so we don't do it
-  - if [ -z "$JRUBY_OPTS" ]; then gem install bundler -v=1.5.3 && alias bundle="bundle _1.5.3_"; fi
+  - if [ "jruby" != "$TRAVIS_RUBY_VERSION"  ]; then gem install bundler; fi
 bundler_args: "--binstubs --standalone --without documentation --path ../bundle"
 script: "script/run_build"
 rvm:


### PR DESCRIPTION
This should fix the builds in the other repos.  They've apparently been broken since rspec/rspec-core#2081 was merged due to the introduction of `:ruby_22` in rspec-core's gemfile.