### PR TITLE
Disable RuboCop style warning for multiline 'expect { ... }'

### DIFF
--- a/travis/.rubocop_rspec_base.yml
+++ b/travis/.rubocop_rspec_base.yml
@@ -118,6 +118,9 @@ StringLiterals:
 Style/SpecialGlobalVars:
   Enabled: false
 
+Style/MultilineTernaryOperator:
+  Enabled: false
+
 Style/TrailingComma:
   Enabled: false
 

--- a/travis/.rubocop_rspec_base.yml
+++ b/travis/.rubocop_rspec_base.yml
@@ -114,6 +114,47 @@ SpaceAroundEqualsInParameterDefault:
 StringLiterals:
   Enabled: false
 
+# This is problematic for Cucumber
+Lint/AmbiguousRegexpLiteral:
+  Exclude:
+    - features/**/*
+
+# In this context, eval is not a "security risk"
+Lint/Eval:
+  Enabled: false
+
+Lint/HandleExceptions:
+  Exclude:
+    - spec/**/*
+
+# RSpec does lots of crazy metaprogramming
+# Defining methods in methods is what we do
+Lint/NestedMethodDefinition:
+  Enabled: false
+
+Lint/RescueException:
+  Exclude:
+    - spec/**/*
+
+Lint/ShadowingOuterLocalVariable:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Style/AlignParameters:
+  Enabled: false
+
+Style/BlockComments:
+  Exclude:
+    - benchmarks/**/*
+
 # RSpec examples use expect { ... } rather than expect do ... end
 Style/Blocks:
   Exclude:
@@ -124,6 +165,10 @@ Style/ClassAndModuleChildren:
   Exclude:
     - spec/**/*
 
+# We sometimes use #kind_of? rather than #is_a?
+Style/ClassCheck:
+  Enabled: false
+
 # Our tests use compact class definitions to save "real estate" on the screen.
 Style/EmptyLineBetweenDefs:
   Exclude:
@@ -133,15 +178,30 @@ Style/EmptyLinesAroundAccessModifier:
   Exclude:
     - spec/**/*
 
+Style/ExtraSpacing:
+  Enabled: false
+
+Style/FirstParameterIndentation:
+  Enabled: false
+
 Style/GlobalVars:
   Exclude:
     - spec/**/*
     - benchmarks/**/*
 
+Style/GuardClause:
+  Enabled: false
+
 # Allow use of: expect { ... }.to raise_error(e) { ... }
 Style/MultilineBlockChain:
   Exclude:
     - spec/**/*
+
+Style/MultilineOperationIndentation:
+  Enabled: false
+
+Style/ParallelAssignment:
+  Enabled: false
 
 # Allow use of: something rescue nil
 Style/RescueModifier:
@@ -152,10 +212,25 @@ Style/RescueModifier:
 Style/Semicolon:
   Exclude:
     - spec/**/*
+    - benchmarks/**/*
 
 Style/SingleLineMethods:
   Exclude:
     - spec/**/*
+
+Style/SingleSpaceBeforeFirstArg:
+  Enabled: false
+
+Style/SpaceAroundOperators:
+  Enabled: false
+
+# Allow 'class Something < Struct.new(:a, :b)'
+Style/StructInheritance:
+  Enabled: false
+
+# Allow 'obj.method { |o| o.something }' rather than 'obj.method(&:something)'
+Style/SymbolProc:
+  Enabled: false
 
 # Allow use of 'something rescue nil' in specs only
 Style/RescueModifier:

--- a/travis/.rubocop_rspec_base.yml
+++ b/travis/.rubocop_rspec_base.yml
@@ -136,6 +136,7 @@ Style/EmptyLinesAroundAccessModifier:
 Style/GlobalVars:
   Exclude:
     - spec/**/*
+    - benchmarks/**/*
 
 # Allow use of: expect { ... }.to raise_error(e) { ... }
 Style/MultilineBlockChain:

--- a/travis/.rubocop_rspec_base.yml
+++ b/travis/.rubocop_rspec_base.yml
@@ -156,7 +156,7 @@ Style/BlockComments:
     - benchmarks/**/*
 
 # RSpec examples use expect { ... } rather than expect do ... end
-Style/Blocks:
+Style/BlockDelimiters:
   Exclude:
     - spec/**/*
 

--- a/travis/.rubocop_rspec_base.yml
+++ b/travis/.rubocop_rspec_base.yml
@@ -160,6 +160,10 @@ Style/SingleLineMethods:
 Style/RescueModifier:
   Enabled: false
 
+# We name block parameters what we want
+Style/SingleLineBlockParams:
+  Enabled: false
+
 # RSpec uses {:a => 1} rather than { :a => 1 }
 Style/SpaceInsideHashLiteralBraces:
   Enabled: false

--- a/travis/.rubocop_rspec_base.yml
+++ b/travis/.rubocop_rspec_base.yml
@@ -114,6 +114,56 @@ SpaceAroundEqualsInParameterDefault:
 StringLiterals:
   Enabled: false
 
+# RSpec examples use expect { ... } rather than expect do ... end
+Style/Blocks:
+  Exclude:
+    - spec/**/*
+
+# In tests, it is convenient to define a test class like RSpec::Something on a single line
+Style/ClassAndModuleChildren:
+  Exclude:
+    - spec/**/*
+
+# Our tests use compact class definitions to save "real estate" on the screen.
+Style/EmptyLineBetweenDefs:
+  Exclude:
+    - spec/**/*
+
+Style/EmptyLinesAroundAccessModifier:
+  Exclude:
+    - spec/**/*
+
+Style/GlobalVars:
+  Exclude:
+    - spec/**/*
+
+# Allow use of: expect { ... }.to raise_error(e) { ... }
+Style/MultilineBlockChain:
+  Exclude:
+    - spec/**/*
+
+# Allow use of: something rescue nil
+Style/RescueModifier:
+  Exclude:
+    - spec/**/*
+
+# Our tests use single-line methods in numerous places. This saves "real estate" on the screen.
+Style/Semicolon:
+  Exclude:
+    - spec/**/*
+
+Style/SingleLineMethods:
+  Exclude:
+    - spec/**/*
+
+# Allow use of 'something rescue nil' in specs only
+Style/RescueModifier:
+  Enabled: false
+
+# RSpec uses {:a => 1} rather than { :a => 1 }
+Style/SpaceInsideHashLiteralBraces:
+  Enabled: false
+
 # This rule favors constant names from the English standard library which we don't load.
 Style/SpecialGlobalVars:
   Enabled: false


### PR DESCRIPTION
By convention, RSpec uses 'expect { ... }'' rather than 'expect do ... end', regardless
of whether the block spans multiple lines or not.