### PR TITLE
Update COC to latest Contributor Covenant version

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -5,33 +5,51 @@ values contributions from anyone, the RSpec project has adopted the
 following code of conduct. All contributors and participants (including
 maintainers!) are expected to abide by its terms.
 
-As contributors and maintainers of this project, we pledge to respect all
-people who contribute through reporting issues, posting feature requests,
-updating documentation, submitting pull requests or patches, and other
-activities.
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
+documentation, submitting pull requests or patches, and other activities.
 
 We are committed to making participation in this project a harassment-free
 experience for everyone, regardless of level of experience, gender, gender
 identity and expression, sexual orientation, disability, personal appearance,
-body size, race, ethnicity, age, religion or similar personal characteristic.
+body size, race, ethnicity, age, religion, or nationality.
 
-Examples of unacceptable behavior by participants include, but are not limited
-to, the use of sexual language or imagery, derogatory comments or personal
-attacks, trolling, public or private harassment, insults, or other
-unprofessional conduct.
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
+* Other unethical or unprofessional conduct
 
 Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct. Project maintainers who do not
-follow the Code of Conduct may be removed from the project team.
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
 
-This code of conduct applies both within project spaces and in public spaces
+By adopting this Code of Conduct, project maintainers commit themselves to
+fairly and consistently applying these principles to every aspect of managing
+this project. Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team.
+
+This Code of Conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by opening an issue or contacting one or more of the project
-maintainers.
+reported by contacting a project maintainer at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. Maintainers are
+obligated to maintain confidentiality with regard to the reporter of an
+incident.
 
-This Code of Conduct is adapted from the [Contributor
-Covenant](http://contributor-covenant.org), version 1.1.0, available at
-[http://contributor-covenant.org/version/1/1/0/](http://contributor-covenant.org/version/1/1/0/)
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.3.0, available at
+[http://contributor-covenant.org/version/1/3/0/][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/


### PR DESCRIPTION
Hello! :wave: 

I wanted to update the github.com/rspec/rspec-support Code of Conduct but when I checked out the file it said not to do so as it is automatically generated and taken from this repository. So, this PR updates your code of conduct to the latest version of the Contributor Covenant.

I don't know which email to add into [INSERT EMAIL ADDRESS HERE], but if you can let me know which address to use I am happy to update it.

Have a fantastic day :rainbow:.