### PR TITLE
Enable Rubygems on Travis CI

### DIFF
--- a/travis/script/functions.sh
+++ b/travis/script/functions.sh
@@ -8,12 +8,6 @@ export JRUBY_OPTS=${JRUBY_OPTS:-"--server -Xcompile.invokedynamic=false"}
 SPECS_HAVE_RUN_FILE=specs.out
 MAINTENANCE_BRANCH=`cat maintenance-branch`
 
-# Don't allow rubygems to pollute what's loaded. Also, things boot faster
-# without the extra load time of rubygems. Only works on MRI Ruby 1.9+
-if is_mri_192_plus; then
-  export RUBYOPT="--disable=gem"
-fi
-
 function clone_repo {
   if [ ! -d $1 ]; then # don't clone if the dir is already there
     travis_retry eval "git clone git://github.com/rspec/$1 --depth 1 --branch $MAINTENANCE_BRANCH"

--- a/travis/script/predicate_functions.sh
+++ b/travis/script/predicate_functions.sh
@@ -30,18 +30,6 @@ function is_mri_192 {
   fi
 }
 
-function is_mri_192_plus {
-  if is_mri; then
-    if ruby -e "exit(RUBY_VERSION.to_f > 1.8)"; then
-      return 0
-    else
-      return 1
-    fi
-  else
-    return 1
-  fi
-}
-
 function is_mri_2plus {
   if is_mri; then
     if ruby -e "exit(RUBY_VERSION.to_f > 2.0)"; then


### PR DESCRIPTION
Nokogiri requires Rubygems to be enabled on build.

* https://github.com/sparklemotion/nokogiri/blob/v1.6.7.1/ext/nokogiri/extconf.rb#L396
* https://travis-ci.org/rspec/rspec-expectations/jobs/100053387#L2799