### PR TITLE
Only enable rubygems for bundle install

### DIFF
--- a/travis/script/predicate_functions.sh
+++ b/travis/script/predicate_functions.sh
@@ -30,6 +30,18 @@ function is_mri_192 {
   fi
 }
 
+function is_mri_192_plus {
+  if is_mri; then
+    if ruby -e "exit(RUBY_VERSION.to_f > 1.8)"; then
+      return 0
+    else
+      return 1
+    fi
+  else
+    return 1
+  fi
+}
+
 function is_mri_2plus {
   if is_mri; then
     if ruby -e "exit(RUBY_VERSION.to_f > 2.0)"; then


### PR DESCRIPTION
Turn off rubygems in our normal build process, but use it during `bundle install` for things like `nokogiri` which expect it to be available during the build process. As suggested by @myronmarston as an improvement to @yujinakayama's PR.

rspec/rspec-core#2152
rspec/rspec-mocks#1051
rspec/rspec-expectations#885
rspec/rspec-rails#1521
rspec/rspec-support#263