### PR TITLE
Force bundler 1.11.2 to be used in Appveyor

### DIFF
--- a/travis/appveyor.yml
+++ b/travis/appveyor.yml
@@ -15,7 +15,7 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - ruby --version
   - gem --version
-  - gem install bundler
+  - gem install bundler -v 1.11.2 # pin 1.11.2 version until later versions work
   - bundler --version
   - bundle install
   - cinst ansicon


### PR DESCRIPTION
Version 1.12.0 does not seem to be working properly.

Refs: https://github.com/rspec/rspec-mocks/pull/1080