### PR TITLE
Remove workaround in Appveyor's configuration

### DIFF
--- a/travis/appveyor.yml
+++ b/travis/appveyor.yml
@@ -15,7 +15,7 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - ruby --version
   - gem --version
-  - gem install bundler -v 1.11.2 # pin 1.11.2 version until later versions work
+  - gem install bundler
   - bundler --version
   - bundle install
   - cinst ansicon


### PR DESCRIPTION
The issue is now fixed upstream, so go back to the old config.