### PR TITLE
Build updates

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -491,7 +491,7 @@ def force_update(branch)
 end
 
 def update_files_in_repos(purpose, suffix='')
-  branch_name = "update-#{purpose.gsub ' ', '-'}-#{Date.today.iso8601}-for-#{BASE_BRANCH}"
+  branch_name = "update-#{purpose.gsub ' ', '-'}-#{ENV.fetch('BRANCH_DATE',Date.today.iso8601)}-for-#{BASE_BRANCH}"
 
   each_project_with_common_build do |proj|
     assert_clean_git_status(proj)

--- a/travis/.travis.yml
+++ b/travis/.travis.yml
@@ -6,7 +6,8 @@ cache:
 before_install:
   - "script/clone_all_rspec_repos"
   # Note this doesn't work on JRUBY 2.0.0 mode so we don't do it, the excluded versions are broken on Ruby 2.3
-  - if [ "jruby" != "$TRAVIS_RUBY_VERSION"  ]; then gem install bundler --version "!= 1.12.0, != 1.12.1"; fi
+  - if [ "jruby" != "$TRAVIS_RUBY_VERSION"  ]; then gem install bundler --version "1.11.2"; fi
+  - alias bundle="bundle _1.11.2_"
 bundler_args: "--binstubs --standalone --without documentation --path ../bundle"
 script: "script/run_build"
 rvm:

--- a/travis/appveyor.yml
+++ b/travis/appveyor.yml
@@ -15,7 +15,7 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - ruby --version
   - gem --version
-  - gem install bundler
+  - gem install bundler -v "!= 1.12.0, != 1.12.1, != 1.12.2, != 1.12.3"
   - bundler --version
   - bundle install
   - cinst ansicon


### PR DESCRIPTION
So it seems Bundler 1.12 is still broken for us, I expect us to be able to remove the version select at some point, but currently we can't install `json` on 2.3.1 on travis, and it also seems to break appveyor with warnings.