### PR TITLE
Tweak sed command for replacing documentation resources

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -66,8 +66,14 @@ task :update_docs, [:version, :branch, :website_path] do |t, args|
     cmd = "bundle install && RUBYOPT='-I#{args[:website_path]}/lib' bundle exec yard --plugin rspec-docs-template --output-dir #{args[:website_path]}/source/documentation/#{args[:version]}/#{project}/"
     puts cmd
     Bundler.clean_system(cmd)
-    Bundler.clean_system %Q{pushd #{args[:website_path]}; ag -l href=\\"\\\(?:..\/\\\)*css | xargs -I{} sed -ibak 's/href="\\\(..\\\/\\\)*css/href="\\\/stylesheets\\\/docs/' {}; popd}
-    Bundler.clean_system %Q{pushd #{args[:website_path]}; ag -l src=\\"\\\(?:..\/\\\)*js | xargs -I{} sed -ibak 's/src="\\\(..\\\/\\\)*js/src="\\\/javascripts\\\/docs/' {}; popd}
+    in_place =
+      if RUBY_PLATFORM =~ /darwin/ # if this is os x then we must modify sed
+        "-i ''"
+      else
+        "-i''"
+      end
+    Bundler.clean_system %Q{pushd #{args[:website_path]}; ag -l href=\\"\\\(?:..\/\\\)*css | xargs -I{} sed #{in_place} 's/href="\\\(..\\\/\\\)*css/href="\\\/stylesheets\\\/docs/' {}; popd}
+    Bundler.clean_system %Q{pushd #{args[:website_path]}; ag -l src=\\"\\\(?:..\/\\\)*js | xargs -I{} sed #{in_place} 's/src="\\\(..\\\/\\\)*js/src="\\\/javascripts\\\/docs/' {}; popd}
   end
 end
 


### PR DESCRIPTION
Modify sed to not use backup files (modify in place) when cleaning up
documentation stylesheets/javascript, due to the differences between
gnu sed and OS X sed the command is slightly different on each platform.