### PR TITLE
Update development setup to use the latest Ruby

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,7 +15,7 @@ rspec-rails.
 The safest bet is to use [rvm](https://github.com/wayneeseguin/rvm) with an rvm
 installed ruby (not system ruby) and a clean gemset dedicated to rspec-dev:
 
-    rvm 1.9.3@rspec-dev --create # or whatever version of Ruby you prefer
+    rvm 2.3.1@rspec-dev --create # or whatever version of Ruby you prefer
 
 [rbenv](https://github.com/sstephenson/rbenv) is also supported.
 


### PR DESCRIPTION
The latest stable version of Ruby is 2.3.1 – it looks like the [`travis.yml` file](https://github.com/rspec/rspec-dev/blob/master/travis/.travis.yml) is already set up to build against it.

I wasn't sure if there was a particular reason this document encourages using version 1.9.3 or if it just went stale. The last version update in the doc seems to have been in 2012 (see https://github.com/rspec/rspec-dev/commit/b00159c6238935f766830f6653cc71ea5e3af494).

Thanks!