### PR TITLE
Make `git clean` check in Rakefile more robust

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -454,7 +454,7 @@ task :version_stats, :commit_ranges do |t, args|
 end
 
 def assert_clean_git_status(name)
-  unless `git status` =~ /nothing to commit,? \(?working directory clean\)?/
+  unless `git status --porcelain`.empty?
     abort "#{name} has uncommitted changes"
   end
 end


### PR DESCRIPTION
The latest git command prints "working tree clean" instead of "working directory clean", and `#assert_clean_git_status` fails even when the repo is actually clean.