### PR TITLE
Disable SimpleCov on JRuby

### DIFF
--- a/travis/script/functions.sh
+++ b/travis/script/functions.sh
@@ -25,7 +25,7 @@ function run_specs_and_record_done {
 
   # rspec-core needs to run with a special script that loads simplecov first,
   # so that it can instrument rspec-core's code before rspec-core has been loaded.
-  if [ -f script/rspec_with_simplecov ]; then
+  if [ -f script/rspec_with_simplecov ] && is_mri; then
     rspec_bin=script/rspec_with_simplecov
   fi;
 


### PR DESCRIPTION
Commit https://github.com/rspec/rspec-core/commit/26dd955abc3bf25a946f6db89c9fb76d2c877c47 was done in rspec-core but it should be done in rspec-dev since the file is auto-generated.