### PR TITLE
Better startup times through --dev

### DIFF
--- a/travis/.travis.yml
+++ b/travis/.travis.yml
@@ -23,24 +23,18 @@ rvm:
   - ruby-head
   - ree
   - rbx
+  - jruby
+  - jruby-head
+  - jruby-18mode
+  - jruby-9.1.12.0
 matrix:
-  include:
-    - rvm: jruby
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false -Xcompat.version=2.0'
-    - rvm: jruby-head
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
-    - rvm: jruby-18mode
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
-    - rvm: jruby
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
-    - rvm: jruby-9.1.2.0
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
   allow_failures:
     - rvm: jruby-head
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
     - rvm: ruby-head
     - rvm: rbx
   fast_finish: true
+env:
+  - JRUBY_OPTS='--dev'
 branches:
   only:
     - master

--- a/travis/.travis.yml
+++ b/travis/.travis.yml
@@ -26,7 +26,7 @@ rvm:
   - jruby
   - jruby-head
   - jruby-18mode
-  - jruby-9.1.12.0
+  - jruby-9.1.2.0
 matrix:
   allow_failures:
     - rvm: jruby-head


### PR DESCRIPTION
Opposed to what I said in rspec/rspec-core#2444 there is something
we can do, I just underestimated its effect. There is `--dev`
(see https://github.com/jruby/jruby/wiki/Improving-startup-time#use-the---dev-flag).

Locally for the rspec-core --bisect spec this brought the runtime
down from 33 to 36 seconds to 21 seconds!

It also encompasses disabling invoke dynamic already, so no need
for that. It is opposed to server mode that was used however,
server mode targets peak performance at the cost of bigger startup
and warmup times and is usually intended for running on the server/
benchmarks. It was introduced for no reason apparent to me in
bc0b97633ef00 and I think --dev fits the use case better and is
closer to what most peeps probably run either way.

Other changes I did:

* collapsed all the envs into one, it shouldn't hurt the other
  elements in the matrix, we lose the compat version 2.0 but
  that doesn't seem too important atm if it is please tell me
* updated the JRuby version to the most current one

runtime comparison:

```
tobi@speedy ~/github/rspec-core $ JRUBY_OPTS='--dev' /usr/bin/time -v bundle exec cucumber features/command_line/bisect.feature:49
Using the default profile...
..............

1 scenario (1 passed)
10 steps (10 passed)
0m18.887s
	Command being timed: "bundle exec cucumber features/command_line/bisect.feature:49"
	User time (seconds): 34.66
	System time (seconds): 1.86
	Percent of CPU this job got: 166%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:21.90
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 255208
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 883560
	Voluntary context switches: 179267
	Involuntary context switches: 2421
	Swaps: 0
	File system inputs: 0
	File system outputs: 1480
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
tobi@speedy ~/github/rspec-core $ JRUBY_OPTS='--server' /usr/bin/time -v bundle exec cucumber features/command_line/bisect.feature:49
Using the default profile...
..............

1 scenario (1 passed)
10 steps (10 passed)
0m28.057s
	Command being timed: "bundle exec cucumber features/command_line/bisect.feature:49"
	User time (seconds): 130.19
	System time (seconds): 2.73
	Percent of CPU this job got: 399%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:33.28
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 358952
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 1499933
	Voluntary context switches: 95373
	Involuntary context switches: 14464
	Swaps: 0
	File system inputs: 0
	File system outputs: 1480
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```