### PR TITLE
Follow change of JRuby versions on Travis CI

### DIFF
--- a/travis/.travis.yml
+++ b/travis/.travis.yml
@@ -25,16 +25,18 @@ rvm:
   - rbx
   - jruby
   - jruby-head
-  - jruby-18mode
-  - jruby-9.1.2.0
+  - jruby-1.7
+env:
+  - JRUBY_OPTS='--dev'
 matrix:
+  include:
+    - rvm: jruby-1.7
+      env: JRUBY_OPTS='--dev --1.8'
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
     - rvm: rbx
   fast_finish: true
-env:
-  - JRUBY_OPTS='--dev'
 branches:
   only:
     - master


### PR DESCRIPTION
We've been used `jruby`, `jruby-head`, `jruby-18mode`, and `jruby-9.1.2.0`, but now they point the following implementations since Travis' recent change:

```
jruby             - JRUBY_VERSION: 9.1.9.0           RUBY_VERSION: 2.3.3
jruby-head        - JRUBY_VERSION: 9.1.10.0-SNAPSHOT RUBY_VERSION: 2.3.3
jruby-18mode      - JRUBY_VERSION: 9.1.7.0           RUBY_VERSION: 2.3.1
jruby-9.1.2.0     - JRUBY_VERSION: 9.1.2.0           RUBY_VERSION: 2.3.0
```

See: https://travis-ci.org/rspec/rspec-support/builds/262713100

So we change them to the followings:

```
jruby             - JRUBY_VERSION: 9.1.9.0           RUBY_VERSION: 2.3.3
jruby-head        - JRUBY_VERSION: 9.1.10.0-SNAPSHOT RUBY_VERSION: 2.3.3
jruby-1.7         - JRUBY_VERSION: 1.7.26            RUBY_VERSION: 1.9.3
jruby-1.7 (--1.8) - JRUBY_VERSION: 1.7.26            RUBY_VERSION: 1.8.7
```