### PR TITLE
Travis: point at rbx-3.84 on Trusty

### DIFF
--- a/travis/.travis.yml
+++ b/travis/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+dist: trusty
 sudo: false
 email: false
 cache:
@@ -22,7 +23,7 @@ rvm:
   - 2.4.1
   - ruby-head
   - ree
-  - rbx
+  - rbx-3.84
   - jruby
   - jruby-head
   - jruby-1.7
@@ -35,7 +36,7 @@ matrix:
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
-    - rvm: rbx
+    - rvm: rbx-3.84
   fast_finish: true
 branches:
   only:


### PR DESCRIPTION
This PR changes the Rubinius line in the CI matrix.

- use 3.84
- this only works on Travis' Trusty dist, so choose that, explicitly