### PR TITLE
Unset _JAVA_OPTIONS env variable on Travis to suppress warning from JVM

### DIFF
--- a/travis/.travis.yml
+++ b/travis/.travis.yml
@@ -5,6 +5,7 @@ cache:
   directories:
     - ../bundle
 before_install:
+  - unset _JAVA_OPTIONS
   - "script/clone_all_rspec_repos"
   # Note this doesn't work on JRUBY 2.0.0 mode so we don't do it, the excluded versions are broken on Ruby 2.3
   - if [ "jruby" != "$TRAVIS_RUBY_VERSION"  ]; then gem install bundler --version "1.11.2"; fi


### PR DESCRIPTION
This fixes #184.

The `_JAVA_OPTIONS` environment variable was recently added on Travis but it seems to be problematic.

* https://github.com/travis-ci/travis-ci/issues/8408
* https://superuser.com/questions/585695/suppressing-the-picked-up-java-options-message