### PR TITLE
Update rubinius reference in Travis CI

### DIFF
--- a/travis/.travis.yml
+++ b/travis/.travis.yml
@@ -23,7 +23,7 @@ rvm:
   - 2.4.1
   - ruby-head
   - ree
-  - rbx
+  - rbx-3
   - jruby
   - jruby-head
   - jruby-1.7
@@ -36,7 +36,7 @@ matrix:
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
-    - rvm: rbx
+    - rvm: rbx-3
   fast_finish: true
 branches:
   only:


### PR DESCRIPTION
Currently it is not running as https://travis-ci.org/rspec/rspec-core/jobs/294537235