### PR TITLE
Unset `RUBYOPT` instead of re-enabling rubygems.

### DIFF
--- a/travis/script/functions.sh
+++ b/travis/script/functions.sh
@@ -181,7 +181,7 @@ function check_documentation_coverage {
 
 function check_style_and_lint {
   echo "bin/rubocop lib"
-  bin/rubocop lib
+  eval "(unset RUBYOPT; exec bin/rubocop lib)"
 }
 
 function run_all_spec_suites {


### PR DESCRIPTION
See: https://github.com/rspec/rspec-dev/commit/3f380ca5b9590ee89c7ade1358b21f9f68bbc25b
Also: https://github.com/rspec/rspec-core/pull/2524#issuecomment-369368627

I will make PR tonight to share those changes to other rspec repos (new ruby versions in `travis.yml` + this workaround for ruby 2.5 and ruby 2.4.3).