### PR TITLE
Remove 1.9.3 from appveyor

### DIFF
--- a/travis/appveyor.yml
+++ b/travis/appveyor.yml
@@ -30,7 +30,6 @@ test_script:
 
 environment:
   matrix:
-    - ruby_version: 193
     - ruby_version: 200
     - ruby_version: 21
     - ruby_version: 22


### PR DESCRIPTION
Ruby 1.9.3 is broken on appveyor, not being able to install from Rubygems, as `rubygems` itself isn't tested on Ruby 1.9.3, and it's a sanity check that we work on Windows, lets drop it from the matrix.

See:
rspec/rspec-core#2566
rspec/rspec-mocks#1239
rspec/rspec-expectations#1075
rspec/rspec-support#352

/cc @myronmarston @samphippen 