### PR TITLE
Update rake to current

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "rake", "~> 11.0.0"
+gem "rake", "~> 12.0.0"
 gem "thor", "~> 0.14.6"
 gem "octokit", "~> 2.7"


### PR DESCRIPTION
Motivated by

```
/path/to/rake-11.0.1/lib/rake/ext/fixnum.rb:4: warning: constant ::Fixnum is deprecated
```

when running `bundle exec rake git:pull`.