### PR TITLE
CI: use 2.4.6, 2.5.5, 2.6.2

### DIFF
--- a/travis/.travis.yml
+++ b/travis/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 email: false
 cache:
   directories:
@@ -18,9 +17,9 @@ rvm:
   - 2.1
   - 2.2.10
   - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0
+  - 2.4.6
+  - 2.5.5
+  - 2.6.2
   - ruby-head
   - ree
   - rbx-3


### PR DESCRIPTION
This PR updates the CI matrix.

  - also: Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration