### PR TITLE
Fix rubocop cops name

### DIFF
--- a/travis/.rubocop_rspec_base.yml
+++ b/travis/.rubocop_rspec_base.yml
@@ -129,7 +129,7 @@ Style/ParallelAssignment:
 Layout/EmptyLineBetweenDefs:
   Enabled: false
 
-Layout/FirstParameterIndentation:
+Layout/IndentFirstArgument:
   Enabled: false
 
 Naming/ConstantName:
@@ -251,7 +251,7 @@ Naming/HeredocDelimiterNaming:
 Layout/EmptyLineAfterMagicComment:
   Enabled: false
 
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   Enabled: false
 
 Layout/IndentAssignment:


### PR DESCRIPTION
```
bin/rubocop lib
Error: The `Layout/FirstParameterIndentation` cop has been renamed to `Layout/IndentFirstArgument`.
(obsolete configuration found in .rubocop_rspec_base.yml, please update it)
The `Layout/IndentArray` cop has been renamed to `Layout/IndentFirstArrayElement`.
(obsolete configuration found in .rubocop_rspec_base.yml, please update it)
```