### PR TITLE
List more rspec gems in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,7 +15,7 @@ rspec-rails.
 The safest bet is to use [rvm](https://github.com/wayneeseguin/rvm) with an rvm
 installed ruby (not system ruby) and a clean gemset dedicated to rspec-dev:
 
-    rvm 2.3.1@rspec-dev --create # or whatever version of Ruby you prefer
+    rvm 2.6@rspec-dev --create # or whatever version of Ruby you prefer
 
 [rbenv](https://github.com/sstephenson/rbenv) is also supported.
 

--- a/README.markdown
+++ b/README.markdown
@@ -120,13 +120,13 @@ If you get a `SSL error` in Windows, you can follow the instructions on this [li
 
 If you get this error `Gem::InstallError: The redcarpet native gem requires installed build tools`, download the development kit from [https://rubyinstaller.org/downloads](https://rubyinstaller.org/downloads). You can follow the installation instructions [here](https://github.com/oneclick/rubyinstaller/wiki/Development-Kit).
 
-## different problem?
+## Different problem?
 
 If you run into a problem not documented here, please check the rspec-dev
 issues tracker to see if someone else has already reported it. If not, please
 add one.
 
-## solution to a problem not documented here?
+## Solution to a problem not documented here?
 
 If you solve a problem that is not documented here, please share the love
 by submitting a patch to this README.

--- a/README.markdown
+++ b/README.markdown
@@ -138,3 +138,10 @@ by submitting a patch to this README.
 * [https://github.com/rspec/rspec-expectations](https://github.com/rspec/rspec-expectations)
 * [https://github.com/rspec/rspec-mocks](https://github.com/rspec/rspec-mocks)
 * [https://github.com/rspec/rspec-rails](https://github.com/rspec/rspec-rails)
+
+## Other gems
+
+* [https://github.com/rspec/rspec-activemodel-mocks](https://github.com/rspec/rspec-activemodel-mocks)
+* [https://github.com/rspec/rspec-collection_matchers](https://github.com/rspec/rspec-collection_matchers)
+* [https://github.com/rspec/rspec-its](https://github.com/rspec/rspec-its)
+* [https://github.com/rspec/rspec-legacy_formatters](https://github.com/rspec/rspec-legacy_formatters)


### PR DESCRIPTION
Close: #46 

I am not sure this is what was expected, but this is a first draft.

I didn't add https://github.com/rspec/rspec-autotest because it doesn't seems maintained/used anymore. @JonRowe you probably knows if we should add it.

Have a nice day.