### PR TITLE
Revert "Prevent rubydoc check running on 2.7.0"

### DIFF
--- a/travis/script/predicate_functions.sh
+++ b/travis/script/predicate_functions.sh
@@ -70,18 +70,6 @@ function is_ruby_25_plus {
   fi
 }
 
-function is_mri_27 {
-  if is_mri; then
-    if ruby -e "exit(RUBY_VERSION.to_f == 2.7)"; then
-      return 0
-    else
-      return 1
-    fi
-  else
-    return 1
-  fi
-}
-
 function rspec_rails_compatible {
   if is_ruby_25_plus; then
     return 0
@@ -106,11 +94,7 @@ function additional_specs_available {
 function documentation_enforced {
   if [ -x ./bin/yard ]; then
     if is_mri_2plus; then
-      if is_mri_27; then
-        return 1
-      else
-        return 0
-      fi
+      return 0
     else
       return 1
     fi


### PR DESCRIPTION
Yard 0.9.21 support Ruby 2.7 now.
https://github.com/lsegal/yard/releases/tag/v0.9.21

This reverts commit 30859b562aa04ca5e3a646b7ee79a36445378706.

Close: https://github.com/rspec/rspec-dev/issues/232