### PR TITLE
Update scripts to run compat specs against Rails 6

### DIFF
--- a/travis/script/predicate_functions.sh
+++ b/travis/script/predicate_functions.sh
@@ -62,6 +62,14 @@ function is_ruby_23_plus {
   fi
 }
 
+function is_ruby_25_plus {
+  if ruby -e "exit(RUBY_VERSION.to_f >= 2.5)"; then
+    return 0
+  else
+    return 1
+  fi
+}
+
 function is_mri_27 {
   if is_mri; then
     if ruby -e "exit(RUBY_VERSION.to_f == 2.7)"; then
@@ -75,7 +83,7 @@ function is_mri_27 {
 }
 
 function rspec_rails_compatible {
-  if is_ruby_23_plus; then
+  if is_ruby_25_plus; then
     return 0
   else
     return 1


### PR DESCRIPTION
Previously, `rspec-rails` compat specs were run against Rails 5, and some of them, specifically ActionCable ones, are only present and run for Rails 6.
This change makes sure `rspec-core`/`rspec-mocks`/`rspec-expectations`/`rspec-support` changes don't break `rspec-rails`'s newer features.

Changes from `ruby_23_plus` to `ruby_25_plus` is required since Rails 6 requires Ruby 2.5+ (compared to 2.2.2+ for Rails 5).

https://github.com/rspec/rspec-support/pull/398
https://github.com/rspec/rspec-core/pull/2691
https://github.com/rspec/rspec-expectations/pull/1159
https://github.com/rspec/rspec-mocks/pull/1314
~https://github.com/rspec/rspec-rails/pull/2269~ - not needed

Related update to use Rails 6 when running specs by default https://github.com/rspec/rspec-rails/pull/2267 (*merged*)

Proof that it works as expected:
https://github.com/rspec/rspec-expectations/pull/1157
https://travis-ci.org/rspec/rspec-expectations/builds/641000927