### PR TITLE
Use .yardopts from each repo when generating documentation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -66,7 +66,7 @@ task :update_docs, [:version, :branch, :website_path] do |t, args|
   each_project :except => UnDocumentedProjects do |project|
     cmd = "bundle install && \
            RUBYOPT='-I#{args[:website_path]}/lib' bundle exec yard \
-                            --yardopts ../.yardopts \
+                            --yardopts .yardopts \
                             --plugin rspec-docs-template \
                             --output-dir #{args[:website_path]}/source/documentation/#{args[:version]}/#{project}/"
     puts cmd

--- a/Rakefile
+++ b/Rakefile
@@ -64,7 +64,11 @@ task :update_docs, [:version, :branch, :website_path] do |t, args|
   args.with_defaults(:website_path => "../rspec.github.io")
   run_command "git checkout #{args[:branch]} && git pull --rebase"
   each_project :except => UnDocumentedProjects do |project|
-    cmd = "bundle install && RUBYOPT='-I#{args[:website_path]}/lib' bundle exec yard --plugin rspec-docs-template --output-dir #{args[:website_path]}/source/documentation/#{args[:version]}/#{project}/"
+    cmd = "bundle install && \
+           RUBYOPT='-I#{args[:website_path]}/lib' bundle exec yard \
+                            --yardopts ../.yardopts \
+                            --plugin rspec-docs-template \
+                            --output-dir #{args[:website_path]}/source/documentation/#{args[:version]}/#{project}/"
     puts cmd
     Bundler.clean_system(cmd)
     in_place =


### PR DESCRIPTION
Related to : https://github.com/rspec/rspec.github.io/pull/131

Each documented RSpec gem have `.yardopts`. The previous was code was using same `../.yardopts` but we want to use specific `yardopts` from each repo.

`rspec-rails` have specific `--exclude` rules for example.

```sh
rspec-dev/ $ find . -iname '.yardopts' -maxdepth 3
./repos/rspec-mocks/.yardopts
./repos/rspec-expectations/.yardopts
./repos/.yardopts
./repos/rspec-core/.yardopts
./repos/rspec-rails/.yardopts
```

