### PR TITLE
Drop --client Java option

### DIFF
--- a/travis/script/functions.sh
+++ b/travis/script/functions.sh
@@ -35,12 +35,9 @@ function run_specs_and_record_done {
 
 function run_cukes {
   if [ -d features ]; then
-    # force jRuby to use client mode JVM or a compilation mode thats as close as possible,
-    # idea taken from https://github.com/jruby/jruby/wiki/Improving-startup-time
-    #
     # Note that we delay setting this until we run the cukes because we've seen
     # spec failures in our spec suite due to problems with this mode.
-    export JAVA_OPTS='-client -XX:+TieredCompilation -XX:TieredStopAtLevel=1'
+    export JAVA_OPTS='-XX:+TieredCompilation -XX:TieredStopAtLevel=1'
 
     echo "${PWD}/bin/cucumber"
 


### PR DESCRIPTION
This option fails `rspec-rails` JRuby jobs with the latest JVM by emitting a warning that it's deprecated. It's better to be slower than fail.

[e.g.](https://travis-ci.org/github/rspec/rspec-rails/jobs/665959013):
```
Warning: the --client flag is deprecated and has no effect most JVMs
```
```
       Diff:
       @@ -1,3 +1,3 @@
        :exit_status => 0,
       -:io => (be blank),
       +:io => "Warning: the --client flag is deprecated and has no effect most JVMs\n",
```

It seems if any one repo has it, it poisons the environment with it somehow.