### PR TITLE
Be able to refer to pull request from rspec-dev in each rspec gems PR

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -372,8 +372,8 @@ namespace :common_plaintext_files do
   end
 
   desc "Updates the common plaintext files files and creates a PR"
-  task :create_pr_with_updates do
-    force_update(update_common_plaintext_files_in_repos, custom_pr_comment)
+  task :create_pr_with_updates :custom_pr_comment do |_t, args|
+    force_update(update_common_plaintext_files_in_repos, args[:custom_pr_comment])
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -224,7 +224,7 @@ def create_pull_request(project_name, branch, custom_pr_comment, base=BASE_BRANC
   github_client.create_pull_request(
     "rspec/#{project_name}", base, branch,
     "Updates from rspec-dev (#{Date.today.iso8601})",
-    "These are some updates, generated from rspec-dev's rake tasks.\n\n#{custom_pr_comment}"
+    ["These are some updates, generated from rspec-dev's rake tasks.", custom_pr_comment].join("\n\n")
   )
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -221,10 +221,15 @@ BASE_BRANCH_MAJOR_VERSION = if BASE_BRANCH == 'master'
                             end
 
 def create_pull_request(project_name, branch, custom_pr_comment, base=BASE_BRANCH)
+  body = [
+    "These are some updates, generated from rspec-dev's rake tasks.",
+    custom_pr_comment
+  ].join("\n\n").strip
+
   github_client.create_pull_request(
     "rspec/#{project_name}", base, branch,
     "Updates from rspec-dev (#{Date.today.iso8601})",
-    ["These are some updates, generated from rspec-dev's rake tasks.", custom_pr_comment].join("\n\n")
+    body
   )
 end
 
@@ -372,7 +377,7 @@ namespace :common_plaintext_files do
   end
 
   desc "Updates the common plaintext files files and creates a PR"
-  task :create_pr_with_updates :custom_pr_comment do |_t, args|
+  task :create_pr_with_updates, :custom_pr_comment do |_t, args|
     force_update(update_common_plaintext_files_in_repos, args[:custom_pr_comment])
   end
 end


### PR DESCRIPTION
I love when we can easily get initial PR when generating PR from rspec-dev. This change add the ability to generate pull request with an additionnal comment.

For example: 
```sh
bundle exec rake "travis:create_pr_with_updates[https://github.com/rspec/rspec-dev/pull/233]"
```

Generates

![Capture d’écran 2020-03-30 à 16 32 52](https://user-images.githubusercontent.com/8417720/77924703-4c634a80-72a4-11ea-99f3-8987fef3c8bb.png)

You can also use:
```
$ bundle exec rake 'common_plaintext_files:create_pr_with_updates[Generated from: https://github.com/rspec/rspec-dev/pull/230]'
```

Will generate pull request with body:

```md
These are some updates, generated from rspec-dev's rake tasks.

Generated from: https://github.com/rspec/rspec-dev/pull/230
```

If no extra comment provided, we simply use this body:
```md
These are some updates, generated from rspec-dev's rake tasks.
```