### PR TITLE
rspec-rails no longer needs to be synced with other rspec gems

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -459,7 +459,7 @@ def confirm_branch_name(name)
 end
 
 def each_project_with_common_build(&b)
-  except = %w[ rspec ]
+  except = %w[ rspec rspec-rails ]
   except << "rspec-support" if BASE_BRANCH_MAJOR_VERSION < 3
   each_project(:except => except, &b)
 end


### PR DESCRIPTION
To avoid [too many automaticly opened pull-request](https://github.com/rspec/rspec-rails/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Aclosed+Updates+from+rspec-dev) on rspec-rails when running `rake travis:create_pr_with_updates`. Disable `rspec-rails`.

Is it something we want @JonRowe ?



