### PR TITLE
Add TruffleRuby to CI

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -151,3 +151,8 @@ maintained by the RSpec team but may receive support and maintenance as needs re
 * [https://github.com/rspec/rspec-collection_matchers](https://github.com/rspec/rspec-collection_matchers)
 * [https://github.com/rspec/rspec-its](https://github.com/rspec/rspec-its)
 * [https://github.com/rspec/rspec-legacy_formatters](https://github.com/rspec/rspec-legacy_formatters)
+
+## Ruby Engine Support
+* Currently only MRI and JRuby releases are officially supported by RSpec.
+* Running RSpec on other Ruby implementations might work, however issues with those implementations should be reported on their issue tracker.
+

--- a/travis/.travis.yml
+++ b/travis/.travis.yml
@@ -29,6 +29,7 @@ rvm:
   - jruby-9.1.7.0 # pin JRuby to this until travis/rvm can install later versions
   - jruby-head
   - jruby-1.7
+  - truffleruby
 env:
   - JRUBY_OPTS='--dev'
 matrix:
@@ -39,6 +40,7 @@ matrix:
     - rvm: jruby-head
     - rvm: ruby-head
     - rvm: rbx-3
+    - rvm: truffleruby
   fast_finish: true
 branches:
   only:


### PR DESCRIPTION
I would like to add TruffleRuby to the CI to track compatibility.