### PR TITLE
Remove rspec-doc-template yard plugin + remove empty lines from HTML doc

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -71,7 +71,7 @@ task :update_docs, [:version, :branch, :website_path] do |t, args|
                             --plugin rspec-docs-template \
                             --output-dir #{args[:website_path]}/source/documentation/#{args[:version]}/#{project}/"
     puts cmd
-    Bundler.clean_system(cmd)
+    Bundler.unbundled_system(cmd)
     in_place =
       if RUBY_PLATFORM =~ /darwin/ # if this is os x then we must modify sed
         "-i ''"
@@ -79,8 +79,8 @@ task :update_docs, [:version, :branch, :website_path] do |t, args|
         "-i''"
       end
 
-    Bundler.clean_system %Q{pushd #{args[:website_path]}; ag -l src=\\"\\\(?:..\/\\\)*js | xargs -I{} sed #{in_place} 's/src="\\\(..\\\/\\\)*js/src="\\\/documentation\\\/#{args[:version]}\\\/#{project}\\\/js/' {}; popd}
-    Bundler.clean_system %Q{pushd #{args[:website_path]}; ag -l href=\\"\\\(?:..\/\\\)*css | xargs -I{} sed #{in_place} 's/href="\\\(..\\\/\\\)*css/href="\\\/documentation\\\/#{args[:version]}\\\/#{project}\\\/css/' {}; popd}
+    Bundler.unbundled_system %Q{pushd #{args[:website_path]}; ag -l src=\\"\\\(?:..\/\\\)*js | xargs -I{} sed #{in_place} 's/src="\\\(..\\\/\\\)*js/src="\\\/documentation\\\/#{args[:version]}\\\/#{project}\\\/js/' {}; popd}
+    Bundler.unbundled_system %Q{pushd #{args[:website_path]}; ag -l href=\\"\\\(?:..\/\\\)*css | xargs -I{} sed #{in_place} 's/href="\\\(..\\\/\\\)*css/href="\\\/documentation\\\/#{args[:version]}\\\/#{project}\\\/css/' {}; popd}
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,7 @@ def run_command(command, opts={})
     FileUtils.cd(path) do
       puts "#{'='*3} #{dir} #{'='*(40 - dir.length)}"
       begin
-        Bundler.clean_system(command)
+        Bundler.unbundled_system(command)
       rescue Exception => e
         puts e.backtrace
       end
@@ -68,7 +68,6 @@ task :update_docs, [:version, :branch, :website_path] do |t, args|
     cmd = "bundle install && \
            RUBYOPT='-I#{args[:website_path]}/lib' bundle exec yard \
                             --yardopts .yardopts \
-                            --plugin rspec-docs-template \
                             --output-dir #{args[:website_path]}/source/documentation/#{args[:version]}/#{project}/"
     puts cmd
     Bundler.unbundled_system(cmd)
@@ -81,6 +80,7 @@ task :update_docs, [:version, :branch, :website_path] do |t, args|
 
     Bundler.unbundled_system %Q{pushd #{args[:website_path]}; ag -l src=\\"\\\(?:..\/\\\)*js | xargs -I{} sed #{in_place} 's/src="\\\(..\\\/\\\)*js/src="\\\/documentation\\\/#{args[:version]}\\\/#{project}\\\/js/' {}; popd}
     Bundler.unbundled_system %Q{pushd #{args[:website_path]}; ag -l href=\\"\\\(?:..\/\\\)*css | xargs -I{} sed #{in_place} 's/href="\\\(..\\\/\\\)*css/href="\\\/documentation\\\/#{args[:version]}\\\/#{project}\\\/css/' {}; popd}
+    Bundler.unbundled_system %Q{pushd #{args[:website_path]}; ag --html -l | xargs -I{} sed #{in_place} /^[[:space:]]*$/d {}; popd}
   end
 end
 


### PR DESCRIPTION
* Remove rspec-doc-template yard plugin. Impact: https://github.com/rspec/rspec.github.io/pull/138
* Remove empty lines generated by rdoc/erb. Impact: https://github.com/rspec/rspec.github.io/pull/139 ⚠️

Related:
- https://github.com/rspec/rspec-rails/pull/2298#discussion_r400436204