### PR TITLE
Stick to last commit from a release when generating new documentation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -63,7 +63,7 @@ desc "Updates the rspec.github.io docs"
 task :update_docs, [:version, :branch, :website_path] do |t, args|
   abort "You must have ag installed to generate docs" if `which ag` == ""
   args.with_defaults(:website_path => "../rspec.github.io")
-  run_command "git checkout #{args[:branch]} && git pull --rebase"
+  run_command "git fetch --tags && git checkout `git tag | grep #{args[:version]} | tail -1`"
   each_project :except => (UnDocumentedProjects + SemverUnlinkedProjects) do |project|
     doc_destination_path = "#{args[:website_path]}/source/documentation/#{args[:version]}/#{project}/"
     cmd = "bundle install && \


### PR DESCRIPTION
This commit is the answer to https://github.com/rspec/rspec.github.io/pull/138#discussion_r404694077

To avoid having documentation with unreleased changes, we stick to the commit of the last release of the MAJOR.MINOR version.  

### Example
With: `bundle exec rake "update_docs[3.9, 3-9-maintenance]"`

args[:version] will be 3.9. The command will search for the latest tag
that match 3.9, for example v3.9.2