### PR TITLE
Be able to generate doc for rspec-rails 4

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -71,7 +71,7 @@ task :update_docs, [:version, :branch, :website_path] do |t, args|
 
     `git checkout #{latest_release}`
     doc_destination_path = "#{args[:website_path]}/source/documentation/#{args[:version]}/#{project}/"
-    cmd = "bundle install && \
+    cmd = "bundle update && \
            RUBYOPT='-I#{args[:website_path]}/lib' bundle exec yard \
                             --yardopts .yardopts \
                             --output-dir #{doc_destination_path}"

--- a/Rakefile
+++ b/Rakefile
@@ -63,13 +63,13 @@ task :update_docs, [:version, :branch, :website_path] do |t, args|
   abort "You must have ag installed to generate docs" if `which ag` == ""
   args.with_defaults(:website_path => "../rspec.github.io")
   each_project :except => (UnDocumentedProjects) do |project|
-    latest_release = `git tag | grep '^v\\\d.\\\d.\\\d$' | grep v#{args[:version]} | tail -1`
+    latest_release = `git fetch --tags && git tag | grep '^v\\\d.\\\d.\\\d$' | grep v#{args[:version]} | tail -1`
 
     if latest_release.empty?
       next "No release found for #{args[:version]} in #{`pwd`}"
     end
 
-    `git fetch --tags && git checkout #{latest_release}`
+    `git checkout #{latest_release}`
     doc_destination_path = "#{args[:website_path]}/source/documentation/#{args[:version]}/#{project}/"
     cmd = "bundle install && \
            RUBYOPT='-I#{args[:website_path]}/lib' bundle exec yard \

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,6 @@ require 'erb'
 
 Projects = ['rspec', 'rspec-core', 'rspec-expectations', 'rspec-mocks', 'rspec-rails', 'rspec-support']
 UnDocumentedProjects = %w[ rspec rspec-support ]
-SemverUnlinkedProjects =  ['rspec-rails']
 BaseRspecPath = Pathname.new(Dir.pwd)
 ReposPath = BaseRspecPath.join('repos')
 
@@ -63,8 +62,14 @@ desc "Updates the rspec.github.io docs"
 task :update_docs, [:version, :branch, :website_path] do |t, args|
   abort "You must have ag installed to generate docs" if `which ag` == ""
   args.with_defaults(:website_path => "../rspec.github.io")
-  run_command "git fetch --tags && git checkout `git tag | grep #{args[:version]} | tail -1`"
-  each_project :except => (UnDocumentedProjects + SemverUnlinkedProjects) do |project|
+  each_project :except => (UnDocumentedProjects) do |project|
+    latest_release = `git tag | grep '^v\\\d.\\\d.\\\d$' | grep v#{args[:version]} | tail -1`
+
+    if latest_release.empty?
+      next "No release found for #{args[:version]} in #{`pwd`}"
+    end
+
+    `git fetch --tags && git checkout #{latest_release}`
     doc_destination_path = "#{args[:website_path]}/source/documentation/#{args[:version]}/#{project}/"
     cmd = "bundle install && \
            RUBYOPT='-I#{args[:website_path]}/lib' bundle exec yard \


### PR DESCRIPTION
With this PR:
- Generate documentation for every last release when they are available. It means we can generate documentation for `rspec-rails` 4 with this code without generating other gems at the moment.
- Fix a bug by not choosing beta or release candidate version like `v4.0.0.rc1`
- Handle major branch change with various `Gemfile` variations. Avoid error like:
<img width="451" alt="Capture d’écran 2020-04-08 à 17 51 45" src="https://user-images.githubusercontent.com/8417720/78805409-aa3d1400-79c1-11ea-9acf-4ea86baa9284.png">

---
For example with:
```sh
$ bundle exec rake "update_docs[4.0, 4-0-maintenance]"
```

We only have rspec-rails with a v4.0.0 version at the moment, so the command will generate documentation only for `rspec-rails` 4.0 documentation, other rspec gem will be skipped.

If we run:
```sh
$ bundle exec rake "update_docs[3.9, 3-9-maintenance]"
```

Every last 3.x release version of documented rspec gems will have their
documentation re-generated.

My main problem is, it not super clear from outside what the command does. Also the command link again `rspec-rails` to other gems in a certain way.