### PR TITLE
Add Ruby3 preview1 to build matrix with allow_failures

### DIFF
--- a/travis/.travis.yml
+++ b/travis/.travis.yml
@@ -23,6 +23,7 @@ rvm:
   - 2.5.8
   - 2.6.6
   - 2.7.1
+  - ruby-3.0.0-preview1
   - ruby-head
   - ree
   - rbx-3
@@ -38,6 +39,7 @@ matrix:
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
+    - rvm: ruby-3.0.0-preview1
     - rvm: rbx-3
   fast_finish: true
 branches:


### PR DESCRIPTION
Hello

https://www.ruby-lang.org/en/news/2020/09/25/ruby-3-0-0-preview1-released/
I choose to be very explicit. `rvm use 3.0.0-preview1` was not working, `rvm use 3` yes but I think we should be explicit when we speak about version. :) 

Have a nice evening