### PR TITLE
Do not allow failures with Ruby 3.0.0-preview1

### DIFF
--- a/travis/.travis.yml
+++ b/travis/.travis.yml
@@ -39,7 +39,6 @@ matrix:
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
-    - rvm: ruby-3.0.0-preview1
     - rvm: rbx-3
   fast_finish: true
 branches:


### PR DESCRIPTION
It is already green on CI for core, mocks, support and expectations. 🙌🏻