### PR TITLE
Updates to Rubocop instructions

### DIFF
--- a/common_plaintext_files/BUILD_DETAIL.md.erb
+++ b/common_plaintext_files/BUILD_DETAIL.md.erb
@@ -92,10 +92,11 @@ $ bundle exec yard doc --no-cache
 $ bin/yard doc --no-cache
 ```
 
-## Rubocop
+## RuboCop
 
-We use [Rubocop](https://github.com/bbatsov/rubocop) to enforce style conventions on the project so
-that the code has stylistic consistency throughout. Run with:
+We use [RuboCop](https://github.com/rubocop-hq/rubocop) to enforce style
+conventions on the project so that the code has stylistic consistency
+throughout. Run with:
 
 ```
 $ bundle exec rubocop lib
@@ -105,9 +106,9 @@ $ bundle exec rubocop lib
 $ bin/rubocop lib
 ```
 
-Our Rubocop configuration is a work-in-progress, so if you get a failure
-due to a Rubocop default, feel free to ask about changing the
-configuration. Otherwise, you'll need to address the Rubocop failure,
+Our RuboCop configuration is a work-in-progress, so if you get a failure
+due to a RuboCop default, feel free to ask about changing the
+configuration. Otherwise, you'll need to address the RuboCop failure,
 or, as a measure of last resort, by wrapping the offending code in
 comments like `# rubocop:disable SomeCheck` and `# rubocop:enable SomeCheck`.
 
@@ -141,4 +142,3 @@ build for another repo, so our CI build includes a spec that runs the
 spec suite of each of the _other_ project repos. Note that we only run
 the spec suite, not the full build, of the other projects, as the spec
 suite runs very quickly compared to the full build.
-

--- a/common_plaintext_files/DEVELOPMENT.md.erb
+++ b/common_plaintext_files/DEVELOPMENT.md.erb
@@ -103,7 +103,7 @@ Here's a short, non-exhaustive checklist of things we typically ask contributors
 - [ ] New behavior is covered by tests and all tests are passing.
 - [ ] No Ruby warnings are issued by your changes.
 - [ ] Documentation reflects changes and renders as intended.
-- [ ] Rubocop passes (e.g. `bundle exec rubocop lib`).
+- [ ] RuboCop passes (e.g. `bundle exec rubocop lib`).
 - [ ] Commits are squashed into a reasonable number of logical changesets that tell an easy-to-follow story.
 - [ ] No changelog entry is necessary (we'll add it as part of the merge process!)
 
@@ -124,4 +124,3 @@ $ bin/yard server --reload
 ```
 
 Then navigate to `localhost:8808` to view the rendered docs.
-


### PR DESCRIPTION
These changes are from rspec/rspec-expectations which were reverted by rspec/rspec-expectations#1254
They should probably be applied to all repos?