### PR TITLE
Fix ruby head

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -578,7 +578,7 @@ def force_update(branch, custom_pr_comment, skip_confirmation=false, opts={})
 end
 
 def update_files_in_repos(purpose, suffix='', opts={})
-  suffix = [BASE_BRANCH, ENV['BRANCH_SUFFIX']].join('-')
+  suffix = [BASE_BRANCH, ENV['BRANCH_SUFFIX']].compact.join('-')
   branch_name = "update-#{purpose.gsub ' ', '-'}-#{ENV.fetch('BRANCH_DATE',Date.today.iso8601)}-for-#{suffix}"
 
   each_project_with_common_build(opts) do |proj|

--- a/ci/.github/workflows/ci.yml
+++ b/ci/.github/workflows/ci.yml
@@ -27,11 +27,13 @@ jobs:
           - 2.3
           - 2.2
           - 2.1.9
-          - ruby-head
         env:
           -
             DIFF_LCS_VERSION: "> 1.4.3"
         include:
+          - ruby: ruby-head
+            env:
+              RUBY_HEAD: true
           - ruby: jruby-9.2.13.0
             env:
               JRUBY_OPTS: "--dev"

--- a/ci/script/predicate_functions.sh
+++ b/ci/script/predicate_functions.sh
@@ -8,6 +8,28 @@ function is_mri {
   fi;
 }
 
+function is_ruby_head {
+  # This checks for the presence of our CI's ruby-head env variable
+  if [ -z ${RUBY_HEAD+x} ]; then
+    return 1
+  else
+    return 0
+  fi;
+}
+
+function supports_cross_build_checks {
+  if is_mri; then
+    # We don't run cross build checks on ruby-head
+    if is_ruby_head; then
+      return 1
+    else
+      return 0
+    fi
+  else
+    return 1
+  fi
+}
+
 function is_jruby {
   if ruby -e "exit(defined?(RUBY_PLATFORM) && RUBY_PLATFORM == 'java')"; then
     # RUBY_ENGINE only returns 'ruby' on MRI.

--- a/ci/script/run_build
+++ b/ci/script/run_build
@@ -25,7 +25,7 @@ if style_and_lint_enforced; then
   fold "rubocop" check_style_and_lint
 fi
 
-if is_mri; then
+if supports_cross_build_checks; then
   fold "one-by-one specs" run_specs_one_by_one
   run_all_spec_suites
 else


### PR DESCRIPTION
Skip our cross build checks on ruby-head, we only need to not run rspec-rails really, but I feel we should focus only on each repo on ruby-head, its going to break at various points anyway (likely) so running a  minimal compatibility check feels better.

https://github.com/rspec/rspec-core/pull/2821
https://github.com/rspec/rspec-expectations/pull/1257
https://github.com/rspec/rspec-mocks/pull/1375
https://github.com/rspec/rspec-support/pull/467