### PR TITLE
Skip coverage checks for cross-builds

### DIFF
--- a/ci/script/run_build
+++ b/ci/script/run_build
@@ -27,6 +27,7 @@ fi
 
 if supports_cross_build_checks; then
   fold "one-by-one specs" run_specs_one_by_one
+  export NO_COVERAGE=true
   run_all_spec_suites
 else
   echo "Skipping the rest of the build on non-MRI rubies"


### PR DESCRIPTION
Sometimes coverage is not consistent across builds for no apparent reason. E.g.:

cross-build https://github.com/rspec/rspec-support/runs/1626127309
```
Coverage report generated for RSpec to /home/runner/work/rspec-support/rspec-expectations/coverage. 3116 / 3596 LOC (86.65%) covered.
```
vs local spec run:
```
2793 relevant lines, 2763 lines covered and 30 lines missed. ( 98.93% ) 
```
vs branch build https://github.com/rspec/rspec-expectations/runs/1626068228?check_suite_focus=true:
```
Coverage report generated for RSpec to /home/runner/work/rspec-expectations/rspec-expectations/coverage. 2905 / 3059 LOC (94.97%) covered.
```
See:
 - https://github.com/rspec/rspec-support/runs/1626127309
 - https://github.com/rspec/rspec-support/pull/477#issuecomment-752517985

Sub-builds:
 - https://github.com/rspec/rspec-support/pull/478
 - https://github.com/rspec/rspec-mocks/pull/1387
 - https://github.com/rspec/rspec-expectations/pull/1271
 - https://github.com/rspec/rspec-core/pull/2835