### PR TITLE
Remove diff-lcs default env var

### DIFF
--- a/ci/.github/workflows/ci.yml
+++ b/ci/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           - 2.3
         env:
           -
-            DIFF_LCS_VERSION: "> 1.4.3"
+            __UNUSED_VARIABLE: "Prevents build error when {matrix.env} is used."
         include:
           - ruby: ruby-head
             env:


### PR DESCRIPTION
It seems to be impossible to:
  - get rid of the whole section due to subsequent env: ${{ matrix.env }}
  - use []
  - use {}
  - use - with no vars

Follow-up fix to:
 - https://github.com/rspec/rspec-support/pull/477
 - https://github.com/rspec/rspec-core/pull/2833
 - https://github.com/rspec/rspec-expectations/pull/1268
 - https://github.com/rspec/rspec-mocks/pull/1384

Sub-prs:
 - https://github.com/rspec/rspec-core/pull/2837
 - https://github.com/rspec/rspec-expectations/pull/1273
 - https://github.com/rspec/rspec-mocks/pull/1389
 - https://github.com/rspec/rspec-support/pull/480