### PR TITLE
Skip coverage checks for cross-builds

### DIFF
--- a/ci/script/run_build
+++ b/ci/script/run_build
@@ -27,6 +27,7 @@ fi
 
 if supports_cross_build_checks; then
   fold "one-by-one specs" run_specs_one_by_one
+  export NO_COVERAGE=true
   run_all_spec_suites
 else
   echo "Skipping the rest of the build on non-MRI rubies"


### PR DESCRIPTION
Sometimes it's not consistent across builds for no apparent reason
https://github.com/rspec/rspec-support/runs/1626127309
https://github.com/rspec/rspec-support/pull/477#issuecomment-752517985

Companion to https://github.com/rspec/rspec-dev/pull/278

Sub-prs:
 - https://github.com/rspec/rspec-support/pull/479
 - https://github.com/rspec/rspec-core/pull/2836
 - https://github.com/rspec/rspec-expectations/pull/1272
 - https://github.com/rspec/rspec-mocks/pull/1388