### PR TITLE
Dont run rubocop on ruby head

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 gem "rake", "~> 12.3.2"
 gem "thor", "~> 0.14.6"
-gem "octokit", "~> 2.7"
+gem "octokit", "~> 4.2"

--- a/Rakefile
+++ b/Rakefile
@@ -555,8 +555,13 @@ def assert_clean_git_status(name)
   end
 end
 
-def confirm_branch_name(name)
+def confirm_branch_name(name, opts={})
   return name unless system("git show-branch #{name} > /dev/null 2>&1")
+
+  if opts[:force]
+    `git branch -D #{name}`
+    return name
+  end
 
   puts "Branch #{name} already exists, delete? [Y/n] or rename new branch? [r[ename] <name>]"
   case input = STDIN.gets.downcase
@@ -620,7 +625,7 @@ def update_files_in_repos(purpose, suffix='', opts={})
   end
 
   each_project_with_common_build(opts) do |name|
-    branch_name = confirm_branch_name(branch_name)
+    branch_name = confirm_branch_name(branch_name, opts)
     sh "git checkout -b #{branch_name}"
 
     yield name

--- a/ci/.github/workflows/ci.yml
+++ b/ci/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          bundler: ${{ matrix.bundler || 2 }}
+          bundler: ${{ matrix.bundler || '2.2.22' }}
           ruby-version: ${{ matrix.ruby }}
       - run: script/update_rubygems_and_install_bundler
       - run: script/clone_all_rspec_repos
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          bundler: 2
+          bundler: '2.2.22'
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: cinst ansicon

--- a/ci/.github/workflows/ci.yml
+++ b/ci/.github/workflows/ci.yml
@@ -61,7 +61,8 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
       - run: script/update_rubygems_and_install_bundler
       - run: script/clone_all_rspec_repos
-      - run: bundle install --binstubs --standalone
+      - run: bundle install --standalone
+      - run: bundle binstubs --all
       - run: script/run_build
 
   legacy:

--- a/ci/script/functions.sh
+++ b/ci/script/functions.sh
@@ -136,10 +136,7 @@ function check_binstubs {
     echo "  $ bundle binstubs$gems"
     echo
     echo "  # To binstub all gems"
-    echo "  $ bundle install --binstubs"
-    echo
-    echo "  # To binstub all gems and avoid loading bundler"
-    echo "  $ bundle install --binstubs --standalone"
+    echo "  $ bundle binstubs --all"
   fi
 
   return $success

--- a/ci/script/functions.sh
+++ b/ci/script/functions.sh
@@ -87,6 +87,7 @@ function run_spec_suite_for {
       unset BUNDLE_GEMFILE
       bundle_install_flags=`cat .github/workflows/ci.yml | grep "bundle install" | sed 's/.* bundle install//'`
       travis_retry eval "(unset RUBYOPT; exec bundle install $bundle_install_flags)"
+      travis_retry eval "(unset RUBYOPT; exec bundle binstubs --all)"
       run_specs_and_record_done
       popd
     else

--- a/ci/script/predicate_functions.sh
+++ b/ci/script/predicate_functions.sh
@@ -126,9 +126,13 @@ function documentation_enforced {
 }
 
 function style_and_lint_enforced {
- if [ -x ./bin/rubocop ]; then
-   return 0
- else
+  if is_ruby_head; then
    return 1
+ else
+   if [ -x ./bin/rubocop ]; then
+     return 0
+   else
+     return 1
+   fi
  fi
 }

--- a/ci/script/update_rubygems_and_install_bundler
+++ b/ci/script/update_rubygems_and_install_bundler
@@ -3,8 +3,8 @@ set -e
 source script/functions.sh
 
 if is_ruby_23_plus; then
-  yes | gem update --system
-  yes | gem install bundler
+  yes | gem update --system '3.2.22'
+  yes | gem install bundler -v '2.2.22'
 else
   echo "Warning installing older versions of Rubygems / Bundler"
   gem update --system '2.7.8'


### PR DESCRIPTION
Originally this PR started as a need to skip rubocop on ruby head as it was failing our builds.

It was extended to update some dependencies for Ruby 3.x, to allow a more consistent "force" approach for updating PRs and  added a pinned bundler version to work around rubygems/rubygems#4754 

PRs:

https://github.com/rspec/rspec-core/pull/2900
https://github.com/rspec/rspec-expectations/pull/1307
https://github.com/rspec/rspec-mocks/pull/1429
https://github.com/rspec/rspec-support/pull/508