### PR TITLE
Update base RuboCop conf to support Ruby 2.4-3.x

### DIFF
--- a/ci/.rubocop_rspec_base.yml
+++ b/ci/.rubocop_rspec_base.yml
@@ -1,76 +1,73 @@
 # This file contains defaults for RSpec projects. Individual projects
 # can customize by inheriting this file and overriding particular settings.
 
-AccessModifierIndentation:
+Layout/AccessModifierIndentation:
   Enabled: false
 
 # "Use alias_method instead of alias"
 # We're fine with `alias`.
-Alias:
+Style/Alias:
   Enabled: false
-
-AlignParameters:
-  EnforcedStyle: with_first_parameter
 
 # "Avoid the use of the case equality operator ==="
 # We prefer using `Class#===` over `Object#is_a?` because `Class#===`
 # is less likely to be monkey patched than `is_a?` on a user object.
-CaseEquality:
+Style/CaseEquality:
   Enabled: false
 
 # Warns when the class is excessively long.
-ClassLength:
+Metrics/ClassLength:
   Max: 100
 
-CollectionMethods:
+Style/CollectionMethods:
   PreferredMethods:
     reduce: 'inject'
 
 # Over time we'd like to get this down, but this is what we're at now.
-CyclomaticComplexity:
+Metrics/CyclomaticComplexity:
   Max: 10
 
 # We use YARD to enforce documentation. It works better than rubocop's
 # enforcement...rubocop complains about the places we re-open
 # `RSpec::Expectations` and `RSpec::Matchers` w/o having doc commments.
-Documentation:
+Style/Documentation:
   Enabled: false
 
 # We still support 1.8.7 which requires trailing dots
-DotPosition:
+Layout/DotPosition:
   EnforcedStyle: trailing
 
-DoubleNegation:
+Style/DoubleNegation:
   Enabled: false
 
 # each_with_object is unavailable on 1.8.7 so we have to disable this one.
-EachWithObject:
+Style/EachWithObject:
   Enabled: false
 
-FormatString:
+Style/FormatString:
   EnforcedStyle: percent
 
 # As long as we support ruby 1.8.7 we have to use hash rockets.
-HashSyntax:
+Style/HashSyntax:
   EnforcedStyle: hash_rockets
 
 # We can't use the new lambda syntax, since we still support 1.8.7.
-Lambda:
+Style/Lambda:
   Enabled: false
 
 # Over time we'd like to get this down, but this is what we're at now.
-LineLength:
+Layout/LineLength:
   Max: 100
 
 # Over time we'd like to get this down, but this is what we're at now.
-MethodLength:
+Metrics/MethodLength:
   Max: 15
 
 # Who cares what we call the argument for binary operator methods?
-BinaryOperatorParameterName:
+Naming/BinaryOperatorParameterName:
   Enabled: false
 
-PercentLiteralDelimiters:
+Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     '%':  ()      # double-quoted string
     '%i': '[]'    # array of symbols
@@ -84,41 +81,44 @@ PercentLiteralDelimiters:
 
 # We have too many special cases where we allow generator methods or prefer a
 # prefixed predicate due to it's improved readability.
-PredicateName:
+Naming/PredicateName:
   Enabled: false
 
 # On 1.8 `proc` is `lambda`, so we use `Proc.new` to ensure we get real procs on all supported versions.
 # http://batsov.com/articles/2014/02/04/the-elements-of-style-in-ruby-number-12-proc-vs-proc-dot-new/
-Proc:
+Style/Proc:
   Enabled: false
 
 # Exceptions should be rescued with `Support::AllExceptionsExceptOnesWeMustNotRescue`
-RescueException:
+Lint/RescueException:
   Enabled: true
 
 # We haven't adopted the `fail` to signal exceptions vs `raise` for re-raises convention.
-SignalException:
+Style/SignalException:
   Enabled: false
 
 # We've tended to use no space, so it's less of a change to stick with that.
-SpaceAroundEqualsInParameterDefault:
+Layout/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: no_space
 
 # We don't care about single vs double qoutes.
-StringLiterals:
+Style/StringLiterals:
   Enabled: false
 
 # This rule favors constant names from the English standard library which we don't load.
 Style/SpecialGlobalVars:
   Enabled: false
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
   Enabled: false
 
 Style/TrailingCommaInArguments:
   Enabled: false
 
-TrivialAccessors:
+Style/TrivialAccessors:
   AllowDSLWriters: true
   AllowPredicates: true
   ExactNameMatch: true
@@ -130,6 +130,15 @@ Layout/EmptyLineBetweenDefs:
   Enabled: false
 
 Layout/FirstParameterIndentation:
+  Enabled: false
+
+Layout/ParameterAlignment:
+  EnforcedStyle: with_first_parameter
+
+Layout/SpaceInsideBlockBraces:
+  Enabled: false
+
+Layout/SpaceInsideParens:
   Enabled: false
 
 Naming/ConstantName:
@@ -159,7 +168,10 @@ Style/IfUnlessModifier:
 Style/IfUnlessModifierOfIfUnless:
   Enabled: false
 
-Style/MethodMissing:
+Lint/MissingSuper:
+  Enabled: false
+
+Style/MissingRespondToMissing:
   Enabled: false
 
 Style/MixinUsage:
@@ -240,24 +252,19 @@ Style/StderrPuts:
 Style/TernaryParentheses:
   Enabled: false
 
-# This could likely be enabled, but it had a false positive on rspec-mocks
-# (suggested change was not behaviour preserving) so I don't trust it.
-Performance/HashEachMethods:
+Naming/HeredocDelimiterNaming:
   Enabled: false
 
-Naming/HeredocDelimiterNaming:
+Layout/AssignmentIndentation:
   Enabled: false
 
 Layout/EmptyLineAfterMagicComment:
   Enabled: false
 
-Layout/IndentArray:
+Layout/FirstArrayElementIndentation:
   Enabled: false
 
-Layout/IndentAssignment:
-  Enabled: false
-
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 
 Layout/SpaceInsidePercentLiteralDelimiters:


### PR DESCRIPTION
Child (dependent) PRs:
 - https://github.com/rspec/rspec-expectations/pull/1342
 - https://github.com/rspec/rspec-core/pull/2927
 - https://github.com/rspec/rspec-mocks/pull/1448
 - https://github.com/rspec/rspec-support/pull/525