### PR TITLE
CI: Update GitHub Action checkout to v3

### DIFF
--- a/ci/.github/workflows/ci.yml
+++ b/ci/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     name: Rubocop
     runs-on: 'ubuntu-20.04'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.0'
@@ -69,7 +69,7 @@ jobs:
     continue-on-error: ${{ matrix.allow_failure || endsWith(matrix.ruby, 'head') }}
     env: ${{ matrix.env }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           bundler: ${{ matrix.bundler || '2.2.22' }}
@@ -114,7 +114,7 @@ jobs:
       LEGACY_CI: true
       JRUBY_OPTS: ${{ matrix.container.jruby_opts || '--dev' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: ${{ matrix.container.pre }}
       - run: script/legacy_setup.sh
       - run: bundle exec bin/rspec
@@ -135,7 +135,7 @@ jobs:
           - 2.1.9
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           bundler: '2.2.22'


### PR DESCRIPTION
This is a trivial update, but it's the latest version.