### PR TITLE
Remove rspec-rails from projects controlled

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require 'time'
 require 'date'
 require 'erb'
 
-Projects = ['rspec', 'rspec-core', 'rspec-expectations', 'rspec-mocks', 'rspec-rails', 'rspec-support']
+Projects = ['rspec', 'rspec-core', 'rspec-expectations', 'rspec-mocks', 'rspec-support']
 UnDocumentedProjects = %w[ rspec rspec-support ]
 BaseRspecPath = Pathname.new(Dir.pwd)
 ReposPath = BaseRspecPath.join('repos')


### PR DESCRIPTION
This PR removes `rspec-rails` from the list of projects to update using these scripts.

That project is no longer updated via this script. Source: a comment on https://github.com/rspec/rspec-rails/pull/2603