### PR TITLE
Set CI permissions to read-only

### DIFF
--- a/ci/.github/workflows/ci.yml
+++ b/ci/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches:
       - '*'
+permissions:
+  contents: read
 env:
   RSPEC_CI: true
   # This tells rspec-rails what branch to run in ci


### PR DESCRIPTION
This just locks down all our repo's permissions as per rspec/rspec-core#2966