### PR TITLE
Extract common github config (dependabot)

### DIFF
--- a/common_plaintext_files/.github/dependabot.yml
+++ b/common_plaintext_files/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This was introduced individually in all repos, e.g. https://github.com/rspec/rspec-core/pull/2994