### PR TITLE
Limit GHA to one active build per workflow/branch

### DIFF
--- a/ci/.github/workflows/ci.yml
+++ b/ci/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 permissions:
   contents: read
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 env:
   RSPEC_CI: true

--- a/ci/.github/workflows/ci.yml
+++ b/ci/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
       - '*'
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 env:
   RSPEC_CI: true
   # This tells rspec-rails what branch to run in ci


### PR DESCRIPTION
This PR ensures that only the last execution per branch always works, even when pushed multiple times in a row, for example. The older one is canceled.

I find myself pushing often, and with many jobs the GHA limit them to a certain amount of concurrently running jobs.
This limit is applied per-org, so if there's a running rspec-rails build means the rspec-core build jobs will spin in a queued state until the first build jobs start to release job slots.

Refs:
 - https://docs.github.com/en/actions/using-jobs/using-concurrency
 - https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/

Credit for this feature that went under my radar goes to @ydah