### PR TITLE
Change the branch name format

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -617,7 +617,7 @@ def should_force?(opts = {})
 end
 
 def update_files_in_repos(purpose, suffix='', opts={})
-  suffix = [BASE_BRANCH, ENV['BRANCH_SUFFIX']].compact.join('-')
+  suffix = [BASE_BRANCH, ENV['BRANCH_SUFFIX']].compact.join('-').sub(/-maintenance$/, '')
   branch_name = "update-#{purpose.gsub ' ', '-'}-#{ENV.fetch('BRANCH_DATE',Date.today.iso8601)}-for-#{suffix}"
 
   each_project_with_common_build(opts) do |proj|


### PR DESCRIPTION
We run double the builds on updates from `rspec-dev` for maintenance branches

```
 RSpec CI / Ruby 3.1 (pull_request) Successful in 4m
 RSpec CI / Ruby 3.1 (push) Successful in 6m
```
[Example](https://github.com/rspec/rspec-core/pull/3000):
![image](https://user-images.githubusercontent.com/6916/211906404-385e0d56-d509-4c6b-a6c8-b67f2a7dd812.png)

due to branch naming (`update-ci-build-scripts-2023-01-11-for-3-12-maintenance`) that falls under this rule:
```
on:
  push:
    branches:
      - 'main'
      - '*-maintenance'
      - '*-dev'
```