### PR TITLE
Switch docker builds to Github container registry.

### DIFF
--- a/ci/.github/workflows/ci.yml
+++ b/ci/.github/workflows/ci.yml
@@ -58,11 +58,6 @@ jobs:
           - ruby: jruby-9.2.13.0
             env:
               JRUBY_OPTS: "--dev"
-          - ruby: jruby-9.1.17.0
-            bundler: 1
-            os: ubuntu-18.04
-            env:
-              JRUBY_OPTS: "--dev"
           - ruby: 2.7
             name_extra: "with diff-lcs 1.3"
             env:
@@ -115,6 +110,9 @@ jobs:
             tag: rspec/ci:jruby-1.7
             jruby_opts: '--dev --1.8'
             pre: gem uninstall jruby-openssl
+            options: "--add-host rubygems.org:151.101.129.227 --add-host api.rubygems.org:151.101.129.227"
+          - version: "JRuby 9.1.17.0"
+            tag: rspec/ci:jruby-9.1.17.0
             options: "--add-host rubygems.org:151.101.129.227 --add-host api.rubygems.org:151.101.129.227"
     env:
       LEGACY_CI: true

--- a/ci/.github/workflows/ci.yml
+++ b/ci/.github/workflows/ci.yml
@@ -92,27 +92,27 @@ jobs:
       matrix:
         container:
           - version: "2.0"
-            tag: rspec/ci:2.0.0
+            tag: ghcr.io/rspec/docker-ci:2.0.0
           - version: "1.9.3"
-            tag: rspec/ci:1.9.3
+            tag: ghcr.io/rspec/docker-ci:1.9.3
           - version: "1.9.2"
-            tag: rspec/ci:1.9.2
+            tag: ghcr.io/rspec/docker-ci:1.9.2
             options: "--add-host rubygems.org:151.101.129.227 --add-host api.rubygems.org:151.101.129.227"
           - version: "1.8.7"
-            tag: rspec/ci:1.8.7
+            tag: ghcr.io/rspec/docker-ci:1.8.7
             options: "--add-host rubygems.org:151.101.129.227 --add-host api.rubygems.org:151.101.129.227"
           - version: "REE"
-            tag: rspec/ci:ree
+            tag: ghcr.io/rspec/docker-ci:ree
             options: "--add-host rubygems.org:151.101.129.227 --add-host api.rubygems.org:151.101.129.227"
           - version: "JRuby 1.7"
-            tag: rspec/ci:jruby-1.7
+            tag: ghcr.io/rspec/docker-ci:jruby-1.7
           - version: "JRuby 1.7 1.8 mode"
-            tag: rspec/ci:jruby-1.7
+            tag: ghcr.io/rspec/docker-ci:jruby-1.7
             jruby_opts: '--dev --1.8'
             pre: gem uninstall jruby-openssl
             options: "--add-host rubygems.org:151.101.129.227 --add-host api.rubygems.org:151.101.129.227"
           - version: "JRuby 9.1.17.0"
-            tag: rspec/ci:jruby-9.1.17.0
+            tag: ghcr.io/rspec/docker-ci:jruby-9.1.17.0
             options: "--add-host rubygems.org:151.101.129.227 --add-host api.rubygems.org:151.101.129.227"
     env:
       LEGACY_CI: true


### PR DESCRIPTION
Docker hub is removing free plans so move our containers to GHCR.