### PR TITLE
Move 2.1.9 to legacy builds

### DIFF
--- a/ci/.github/workflows/ci.yml
+++ b/ci/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
           - 2.4
           - 2.3
           - 2.2
-          - 2.1.9
         env:
           -
             DIFF_LCS_VERSION: "> 1.4.3"
@@ -91,6 +90,9 @@ jobs:
       fail-fast: false
       matrix:
         container:
+          - version: "2.1.9"
+            tag: ghcr.io/rspec/docker-ci:2.1.9
+            post: git config --global --add safe.directory `pwd`
           - version: "2.0"
             tag: ghcr.io/rspec/docker-ci:2.0.0
           - version: "1.9.3"
@@ -121,6 +123,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: ${{ matrix.container.pre }}
       - run: script/legacy_setup.sh
+      - run: ${{ matrix.container.post }}
       - run: bundle exec bin/rspec
       - run: bundle exec script/cucumber.sh
 
@@ -136,7 +139,6 @@ jobs:
           - 2.4
           - 2.3
           - 2.2
-          - 2.1.9
       fail-fast: false
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Source for:

rspec/rspec-core#3028
rspec/rspec-expectations#1414
rspec/rspec-mocks#1541
rspec/rspec-support#573

Ruby 2.1.9 ceased working on GHA directly so is moved to the legacy docker setup.
