### PR TITLE
Remove Relish references

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -643,12 +643,6 @@ task :default do
   run_command "bin/rake"
 end
 
-desc "publish cukes to relishapp.com"
-task :relish, :version do |_, args|
-  raise "rake relish[VERSION]" unless args[:version]
-  run_command "bin/rake relish['#{args[:version]}']", :except => ['rspec']
-end
-
 desc "generate release notes from changelogs"
 task :release_notes, :target do |_, args|
 

--- a/common_plaintext_files/BUILD_DETAIL.md.erb
+++ b/common_plaintext_files/BUILD_DETAIL.md.erb
@@ -45,7 +45,7 @@ project-specific threshold, the build will fail.
 ## Cukes
 
 RSpec uses [cucumber](https://cucumber.io/) for both acceptance testing
-and [documentation](https://relishapp.com/rspec). Since we publish our cukes
+and [documentation](https://rspec.info/documentation). Since we publish our cukes
 as documentation, please limit new cucumber scenarios to user-facing examples
 that help demonstrate usage. Any tests that exist purely to prevent regressions
 should be written as specs, even if they are written in an acceptance style.

--- a/common_plaintext_files/CONTRIBUTING.md.erb
+++ b/common_plaintext_files/CONTRIBUTING.md.erb
@@ -8,7 +8,7 @@ If you'd like to help make RSpec better, here are some ways you can contribute:
   - by running RSpec HEAD to help us catch bugs before new releases
   - by [reporting bugs you encounter](https://github.com/rspec/<%= project_name %>/issues/new) with [report template](#report-template)
   - by [suggesting new features](https://github.com/rspec/<%= project_name %>/issues/new)
-  - by improving RSpec's [Relish](https://relishapp.com/rspec) or [API](https://rspec.info/documentation/) documentation
+  - by improving RSpec's Feature or API [documentation](https://rspec.info/documentation/)
   - by improving [RSpec's website](https://rspec.info/) ([source](https://github.com/rspec/rspec.github.io))
   - by taking part in [feature and issue discussions](https://github.com/rspec/<%= project_name %>/issues)
   - by adding a failing test for reproducible [reported bugs](https://github.com/rspec/<%= project_name %>/issues)


### PR DESCRIPTION
Removes Relish references from common markdown:

- rspec/rspec-core#3033
- rspec/rspec-expectations#1418
- rspec/rspec-mocks#1544
- rspec/rspec-support#576