### PR TITLE
CI: refer to JRuby 9.2, 9.3, 9.4

### DIFF
--- a/ci/.github/workflows/ci.yml
+++ b/ci/.github/workflows/ci.yml
@@ -54,7 +54,13 @@ jobs:
           - ruby: ruby-head
             env:
               RUBY_HEAD: true
-          - ruby: jruby-9.2.13.0
+          - ruby: jruby-9.4
+            env:
+              JRUBY_OPTS: "--dev"
+          - ruby: jruby-9.3
+            env:
+              JRUBY_OPTS: "--dev"
+          - ruby: jruby-9.2
             env:
               JRUBY_OPTS: "--dev"
           - ruby: 2.7


### PR DESCRIPTION
This PR introduces more JRuby versions to the build matrix.

