### PR TITLE
Upgrade checkout to v4 where possible

### DIFF
--- a/ci/.github/workflows/ci.yml
+++ b/ci/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     name: Rubocop
     runs-on: 'ubuntu-20.04'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.0'
@@ -69,7 +69,7 @@ jobs:
     continue-on-error: ${{ matrix.allow_failure || endsWith(matrix.ruby, 'head') }}
     env: ${{ matrix.env }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           bundler: ${{ matrix.bundler || '2.2.22' }}
@@ -141,7 +141,7 @@ jobs:
           - 2.2
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           bundler: '2.2.22'


### PR DESCRIPTION
Inspired by dependabot, but leaving the legacy build alone, merged in:

rspec/rspec-core#3048
rspec/rspec-expectations#1431
rspec/rspec-mocks#1555
rspec/rspec-support#585