### PR TITLE
Updated documentation to reflect current requirements and package names

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -61,9 +61,8 @@ like this:
 After the initial clone you can run `rake git:pull` from the rspec-dev
 directory to update all of the rspec repos (in repos). Note that the update script 
 will look for the repos all under the same user as rspec-dev, so if you have forked this repo, 
-you need to fork them all. The rspec metagem is now available [here](https://github.com/rspec/rspec-metagem)
-and you will need to rename your fork rspec,
-
+you need to fork them all.
+ 
 Run `rake -T` to see the available tasks for dev mode.
 
 # Contributing

--- a/README.markdown
+++ b/README.markdown
@@ -9,6 +9,7 @@ rspec-rails.
 
     git
     sqlite3 # for rspec-rails
+    the_silver_searcher # for update_docs
 
 ### Ruby
 
@@ -58,7 +59,10 @@ like this:
         rspec              # meta-gem that depends on core, expectations, and mocks
 
 After the initial clone you can run `rake git:pull` from the rspec-dev
-directory to update all of the rspec repos (in repos).
+directory to update all of the rspec repos (in repos). Note that the update script 
+will look for the repos all under the same user as rspec-dev, so if you have forked this repo, 
+you need to fork them all. The rspec metagem is now available [here](https://github.com/rspec/rspec-metagem)
+and you will need to rename your fork rspec,
 
 Run `rake -T` to see the available tasks for dev mode.
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,8 +6,8 @@ require 'time'
 require 'date'
 require 'erb'
 
-Projects = ['rspec', 'rspec-core', 'rspec-expectations', 'rspec-mocks', 'rspec-rails', 'rspec-support']
-UnDocumentedProjects = %w[ rspec rspec-support ]
+Projects = ['rspec-metagem', 'rspec-core', 'rspec-expectations', 'rspec-mocks', 'rspec-rails', 'rspec-support']
+UnDocumentedProjects = %w[ rspec-metagem rspec-support ]
 BaseRspecPath = Pathname.new(Dir.pwd)
 ReposPath = BaseRspecPath.join('repos')
 MAX_PROJECT_NAME_LENGTH = Projects.map(&:length).max
@@ -563,7 +563,7 @@ namespace :common_plaintext_files do
 
   COMMON_PLAINTEXT_EXCLUSIONS =
     {
-      'rspec' =>
+      'rspec-metagem' =>
         %w[BUILD_DETAIL.md.erb CONTRIBUTING.md.erb DEVELOPMENT.md.erb ISSUE_TEMPLATE.md.erb REPORT_TEMPLATE.md],
       'rspec-rails' => %w[ISSUE_TEMPLATE.md.erb REPORT_TEMPLATE.md]
     }
@@ -671,7 +671,7 @@ end
 
 desc "Lists stats generated from the logs for the provided commit ranges"
 task :version_stats, :commit_ranges do |t, args|
-  projects = Projects - ["rspec"]
+  projects = Projects - ["rspec-metagem"]
 
   puts
   puts "### Combined: "
@@ -717,7 +717,7 @@ def confirm_branch_name(name, opts={})
 end
 
 def each_project_with_common_build(opts={}, &b)
-  except = %w[ rspec ]
+  except = %w[ rspec-metagem ]
   except += Array(opts[:except])
   except << "rspec-support" if BASE_BRANCH_MAJOR_VERSION < 3
   each_project(:except => except, &b)


### PR DESCRIPTION
This PR updates the README documentation to:

1. Identify `the_silver_surfer` as a required package (since the error only identifies the binary name "ag" which is too short to be accurately googled and has a Ruby gem by the same name that is not the right thing)
2. Identify that users will need to fork all repositories used by `rspec-dev` based on how it looks up the URL (since otherwise they are just faced with repository not found errors). 
3. Update the Rakefile to reflect the new name of the `rspec-metagem` repository. If a user is forking all the repositories to make this repo work, then they won't have the `rspec`->`rspec-metagem` redirect set up and will need to pull it from the proper name.

Feel free to not merge this pull request if it is not in line with your project's direction. These were just stumbling blocks I ran across as I tried to update the `rspec/rspec-expectations` documentation and I'm hopeful they will help others looking to contribute to your project as well!