### PR TITLE
Allow legacy builds to use older node

### DIFF
--- a/ci/.github/workflows/ci.yml
+++ b/ci/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
             tag: ghcr.io/rspec/docker-ci:jruby-9.1.17.0
             options: "--add-host rubygems.org:151.101.129.227 --add-host api.rubygems.org:151.101.129.227"
     env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       LEGACY_CI: true
       JRUBY_OPTS: ${{ matrix.container.jruby_opts || '--dev' }}
       NO_COVERAGE: true


### PR DESCRIPTION
https://github.com/rspec/rspec-core/pull/3098
https://github.com/rspec/rspec-expectations/pull/1468
https://github.com/rspec/rspec-mocks/pull/1579
https://github.com/rspec/rspec-support/pull/603