### PR TITLE
Add workaround for cucumber on ruby-head

### DIFF
--- a/ci/script/functions.sh
+++ b/ci/script/functions.sh
@@ -65,6 +65,13 @@ function run_cukes {
       RUBYOPT="-I${PWD}/../bundle -rbundler/setup" \
          PATH="${PWD}/bin:$PATH" \
          bin/cucumber --strict
+    elif is_ruby_head; then
+      # This is a monkey patch to fix an issue with cucumber using outdated hash syntax, remove when cucumber is updated or ruby 3.4 released
+      sed -i '$i\class Hash; alias :__initialize :initialize; def initialize(*args, **_kw, &block) = __initialize(*args, &block); end' bin/cucumber
+
+      RUBYOPT="${RUBYOPT} -I${PWD}/../bundle -rbundler/setup" \
+         PATH="${PWD}/bin:$PATH" \
+         bin/cucumber --strict
     else
       # Prepare RUBYOPT for scenarios that are shelling out to ruby,
       # and PATH for those that are using `rspec` or `rake`.


### PR DESCRIPTION
Sideload a fix for cucumber on ruby-head, as there is a change to hash behaviour imcompatible with the current version.

Relevant PRs:

https://github.com/rspec/rspec-core/pull/3102
https://github.com/rspec/rspec-expectations/pull/1474
https://github.com/rspec/rspec-mocks/pull/1582
https://github.com/rspec/rspec-support/pull/608