### PR TITLE
Fix rails build

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -236,9 +236,9 @@ task :update_docs, [:version, :website_path, :branch] do |_t, args|
         `git fetch --tags && git tag -l "v#{args[:version]}*" | grep v#{args[:version]} | tail -1`
       end
 
-    if args[:branch].empty? && latest_release.empty?
+    if (args[:branch].nil? || args[:branch].empty?) && latest_release.empty?
       skipped << project
-    elsif args[:branch].empty?
+    elsif args[:branch].nil? || args[:branch].empty?
       projects[project] = latest_release
     else
       projects[project] = args[:branch]

--- a/ci/script/predicate_functions.sh
+++ b/ci/script/predicate_functions.sh
@@ -109,13 +109,8 @@ function is_ruby_31_plus {
 }
 
 function rspec_rails_compatible {
-  if is_ruby_25_plus; then
-    # TODO remove when RSpec-Rails build is 3.1 safe by default
-    if is_ruby_31_plus; then
-      return 1
-    else
-      return 0
-    fi
+  if is_ruby_27_plus; then
+    return 0
   else
     return 1
   fi


### PR DESCRIPTION
RSpec Rails 7.0.0 changed its minimum supported Ruby in line with Rails itself, so we need to fix that, but we can also relax a previous constraint which was fixed.

https://github.com/rspec/rspec-core/pull/3108
https://github.com/rspec/rspec-expectations/pull/1482
https://github.com/rspec/rspec-mocks/pull/1588
https://github.com/rspec/rspec-support/pull/613